### PR TITLE
Beef up CI examples, dont quit on failure when running examples.

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -71,10 +71,25 @@ jobs:
       - name: Example set (short, 100 steps)
         run: |
           cat > examples-complete.txt <<'EOF'
-          TestCases/NavierStokes/2D/LidDrivenCavity/config.json
+          TestCases/Euler/1D/Problem123/config.json
+          TestCases/Euler/1D/ShuOsherShock/config.json
           TestCases/Euler/1D/SodShockTube/config.json
-          TestCases/Euler/2D/IsentropicVortex/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWave/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWaveCollision/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWaveLeft/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWaveRight/config.json
+          TestCases/Euler/1D/AcousticWave/config.json
+          TestCases/Euler/1D/LaxShockTube/config.json
+          TestCases/Euler/1D/LeBlancShockTube/config.json
+          TestCases/Euler/1D/ModifiedSodShockTube/config.json
           TestCases/Euler/2D/ForwardFacingStep/config.json
+          TestCases/Euler/2D/IsentropicVortex/config.json
+          TestCases/Euler/2D/KelvinHelmholtzInstability/config.json
+          TestCases/Euler/2D/Nagashima_Ramjet/TR0/config.json
+          TestCases/Euler/2D/Ramp/config.json
+          TestCases/Euler/2D/BackwardFacingStep/config.json
+          TestCases/Euler/2D/TriplePointShockInteraction/config.json
+          TestCases/NavierStokes/2D/LidDrivenCavity/config.json
           EOF
           scripts/test_run_example.sh -l examples-complete.txt -n 100
 

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -69,13 +69,25 @@ jobs:
       - name: Example set (broader, 150–200 steps)
         run: |
           cat > examples-nightly.txt <<'EOF'
-          TestCases/NavierStokes/2D/LidDrivenCavity/config.json
-          TestCases/Euler/1D/SodShockTube/config.json
+          TestCases/Euler/1D/Problem123/config.json
           TestCases/Euler/1D/ShuOsherShock/config.json
-          TestCases/Euler/2D/IsentropicVortex/config.json
-          TestCases/Euler/2D/DoubleMachReflection/config.json
-          TestCases/Euler/2D/KelvinHelmholtzInstability/config.json
+          TestCases/Euler/1D/SodShockTube/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWave/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWaveCollision/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWaveLeft/config.json
+          TestCases/Euler/1D/WoodwardColellaBlastWaveRight/config.json
+          TestCases/Euler/1D/AcousticWave/config.json
+          TestCases/Euler/1D/LaxShockTube/config.json
+          TestCases/Euler/1D/LeBlancShockTube/config.json
+          TestCases/Euler/1D/ModifiedSodShockTube/config.json
           TestCases/Euler/2D/ForwardFacingStep/config.json
+          TestCases/Euler/2D/IsentropicVortex/config.json
+          TestCases/Euler/2D/KelvinHelmholtzInstability/config.json
+          TestCases/Euler/2D/Nagashima_Ramjet/TR0/config.json
+          TestCases/Euler/2D/Ramp/config.json
+          TestCases/Euler/2D/BackwardFacingStep/config.json
+          TestCases/Euler/2D/TriplePointShockInteraction/config.json
+          TestCases/NavierStokes/2D/LidDrivenCavity/config.json
           EOF
           scripts/test_run_example.sh -l examples-nightly.txt -n 200
 

--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -93,6 +93,9 @@ jobs:
           scripts/test_run_example.sh \
             -c TestCases/NavierStokes/2D/LidDrivenCavity/config.json \
             -n 100
+          scripts/test_run_example.sh \
+            -c TestCases/Euler/2D/IsentropicVortex/config.json \
+            -n 100
 
       - name: Unit smoke tests
         run: ctest --test-dir build -L smoke -j2 --output-on-failure

--- a/scripts/test_run_example.sh
+++ b/scripts/test_run_example.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# --- Harness state (do NOT set -e inside per-case runs) ---
+declare -a SUCCEEDED=()
+declare -a FAILED=()
+
+# Zero-pad cycle index to 6 digits: 0 -> 000000, 100 -> 000100
+fmt_cycle() {
+  printf "%06d" "${1:-0}"
+}
+
+# Verify expected ParaView outputs exist for N steps under out/ParaView
+# Requires ParaView.pvd and both Cycle000000 and Cycle00NNNN
+check_outputs() {
+  local outdir="$1" ; local nsteps="$2"
+  local pv="${outdir}/ParaView/ParaView.pvd"
+  local c0="${outdir}/ParaView/Cycle$(fmt_cycle 0)"
+  local cN="${outdir}/ParaView/Cycle$(fmt_cycle "${nsteps}")"
+  [[ -f "${pv}" && -d "${c0}" && -d "${cN}" ]]
+}
+
+
 # Default knobs
 NSTEPS=100
 TOP=$(pwd)
@@ -108,24 +128,47 @@ run_one() {
         | .paraview  = true
         | .visit     = false
         | .nancheck  = true
-        | .vis_steps = (((($N/2)|floor) | if .==0 then 1 else . end))
+        # favor 10-step cadence when divisible to ensure Cycle000000 & Cycle00NNNN appear
+        | .vis_steps = ( if ($N % 10 == 0) then 10
+                         else (((($N/2)|floor) | if .==0 then 1 else . end))
+                         end )
         | .variable_dt = false
         | ( if (.dt? | isnum) then .
             elif (.final_time? | isnum) then (.dt = (.final_time / $N))
-            else (.dt = 0.001)
+            else (.dt = 0.000001)
           end )
         | .final_time = (.dt * $N)
         | .output_file_path = $out
+        | .checkpoint_load = false
       )
   ' "${cfg_abs}" > "${patched}"
 
   # Run from the per-example dir; keep your “two levels down” invariant
+  # Run example (isolate failures; do NOT exit on first error)
+  set +e
   ( cd "${work}" && mpiexec -n 2 ../Prandtl -c "${patched}" )
+  local run_rc=$?
+  set -e
 
-  # Basic regression hook: ensure at least one file in out/ParaView
-  if ! find "${outdir}/ParaView" -type f -maxdepth 1 -print -quit | grep -q .; then
-    echo "ERROR: No output files produced in ${outdir}" >&2
-    return 2
+  # Basic regression: require ParaView.pvd + Cycle000000 + Cycle00NNNN
+  if [[ ${run_rc} -eq 0 ]] && check_outputs "${outdir}" "${NSTEPS}"; then
+    echo "✓ Example OK: ${exname} (outputs in ${outdir})"
+    SUCCEEDED+=("${cfg_rel}")
+    return 0
+  else
+    echo "✗ Example FAILED: ${exname}"
+    [[ ${run_rc} -ne 0 ]] && echo "  - runtime exit code: ${run_rc}"
+    if [[ ! -f "${outdir}/ParaView/ParaView.pvd" ]]; then
+      echo "  - missing: ${outdir}/ParaView/ParaView.pvd"
+    fi
+    if [[ ! -d "${outdir}/ParaView/Cycle$(fmt_cycle 0)" ]]; then
+      echo "  - missing: ${outdir}/ParaView/Cycle$(fmt_cycle 0)"
+    fi
+    if [[ ! -d "${outdir}/ParaView/Cycle$(fmt_cycle "${NSTEPS}")" ]]; then
+      echo "  - missing: ${outdir}/ParaView/Cycle$(fmt_cycle "${NSTEPS}")"
+    fi
+    FAILED+=("${cfg_rel}")
+    return 1
   fi
 
   echo "✓ Example OK: ${exname} (outputs in ${outdir})"
@@ -134,9 +177,21 @@ run_one() {
 # ---- Iterate
 rc=0
 for cfg in "${CFGS[@]}"; do
-  if ! run_one "${cfg}"; then
-    rc=1
-  fi
+  # if ! run_one "${cfg}"; then
+  #  rc=1
+  # fi
+  run_one "${cfg}" || rc=1
 done
+
+# ---- Summary
+echo
+echo "===== Example Summary ====="
+echo "Total: ${#CFGS[@]} | Succeeded: ${#SUCCEEDED[@]} | Failed: ${#FAILED[@]}"
+if (( ${#SUCCEEDED[@]} > 0 )); then
+  printf '  ✓ %s\n' "${SUCCEEDED[@]}"
+fi
+if (( ${#FAILED[@]} > 0 )); then
+  printf '  ✗ %s\n' "${FAILED[@]}"
+fi
 
 exit ${rc}


### PR DESCRIPTION
## Pull Request Overview

This PR enhances CI example testing by implementing non-failing execution and expanding test coverage. The changes allow all examples to run to completion even when individual tests fail, providing better visibility into overall test status.

**Key Changes:**
- Modified test harness to track and report success/failure states instead of exiting on first failure
- Added enhanced output verification checking for ParaView files across multiple simulation cycles
- Expanded example test coverage in CI workflows with additional 1D and 2D test cases

### Reviewed Changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 1 comment.

| File | Description |
| ---- | ----------- |
| scripts/test_run_example.sh | Added failure tracking arrays, output verification logic, and summary reporting; modified to continue execution after failures |
| .github/workflows/ci-quick.yml | Added InviscidVortex example to quick CI tests |
| .github/workflows/ci-nightly.yml | Expanded nightly test suite with 11 additional Euler examples and reorganized list |
| .github/workflows/ci-complete.yml | Expanded complete test suite with same additional examples as nightly workflow |

##### (copilot-generated)