### PR TITLE
Update README with CI workflow status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prandtl - A High-Order DGSEM CFD Solver
 | Workflow | Purpose | Status |
-|-----------|----------|--------|
+| --- | --- | --- |
 | **CI Quick** | Fast PR gating (build + smoke) | [![CI Quick](https://github.com/chess-uiuc/Prandtl/actions/workflows/ci-quick.yml/badge.svg)](https://github.com/chess-uiuc/Prandtl/actions/workflows/ci-quick.yml) |
 | **CI Complete** | Full sanitizer & example run (label `full-ci`) | [![CI Complete](https://github.com/chess-uiuc/Prandtl/actions/workflows/ci-complete.yml/badge.svg)](https://github.com/chess-uiuc/Prandtl/actions/workflows/ci-complete.yml) |
 | **Nightly** | Coverage + extended examples (cron) | [![Nightly](https://github.com/chess-uiuc/Prandtl/actions/workflows/ci-nightly.yml/badge.svg)](https://github.com/chess-uiuc/Prandtl/actions/workflows/ci-nightly.yml) |


### PR DESCRIPTION
## Pull Request Overview

This PR adds a CI/CD workflow status table to the README, providing visibility into the project's continuous integration pipelines. The table displays GitHub Actions badges for three different workflows with their respective purposes.

- Adds a status table for three CI workflows: CI Quick, CI Complete, and Nightly
- Includes GitHub Actions badges linking to the respective workflow pages

##### (copilot-generated)