### PR TITLE
Add state wrapper/accessor and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(Prandtl)
 option(BUILD_TESTING "Build unit tests" ON)
 option(PARABOLIC "Enable Compressible Navier-Stokes Solver" OFF)
 option(SUBCELL_FV_BLENDING "Enable subcell blending" ON)
+option(AXISYMMETRIC "Enable Axisymmetric domain solver" OFF)
 
 find_package(MPI REQUIRED)
 include_directories(${MPI_CXX_INCLUDE_PATH})
@@ -22,43 +23,49 @@ message(STATUS "MPI CXX COMPILER: ${MPI_CXX_COMPILER}")
 message(STATUS "MPI INCLUDE PATH: ${MPI_INCLUDE_PATH}")
 message(STATUS "MPI LIBRARIES: ${MPI_CXX_LIBRARIES}")
 
-# Set the CONFIG_FILE variable, with a default if not provided
-set(CONFIG_FILE "${CONFIG_FILE}" CACHE STRING "Path to config file")
-
-message(STATUS "CONFIG_FILE = ${CONFIG_FILE}")
+add_executable(${PROJECT_NAME} main.cpp)
 
 # --- Python Script for Compile Definitions ---
 set(CONFIG_FILE "${CONFIG_FILE}" CACHE STRING "Path to config file")
-message(STATUS "CONFIG_FILE = ${CONFIG_FILE}")
-
 if(IS_ABSOLUTE "${CONFIG_FILE}")
     set(FULL_CONFIG_PATH "${CONFIG_FILE}")
 else()
     set(FULL_CONFIG_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${CONFIG_FILE}")
 endif()
+message(STATUS "CONFIG_FILE = ${CONFIG_FILE}")
+if(NOT "${CONFIG_FILE}" STREQUAL "")
+    message(STATUS "Parsing configuration file: ${FULL_CONFIG_PATH}")
+    execute_process(
+        COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/parse_compile_config.py" "${FULL_CONFIG_PATH}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        OUTPUT_VARIABLE COMPILE_DEFINES
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )       
+    string(REPLACE "\n" ";" COMPILE_DEFINES_LIST "${COMPILE_DEFINES}")
+    message(STATUS "COMPILE_DEFINES_LIST = ${COMPILE_DEFINES_LIST}")
 
-execute_process(
-    COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/parse_compile_config.py"
-                    "${FULL_CONFIG_PATH}"
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    OUTPUT_VARIABLE COMPILE_DEFINES
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-string(REPLACE "\n" ";" COMPILE_DEFINES_LIST "${COMPILE_DEFINES}")
-message(STATUS "COMPILE_DEFINES_LIST = ${COMPILE_DEFINES_LIST}")
-
-add_executable(${PROJECT_NAME} main.cpp)
-
-target_compile_definitions(${PROJECT_NAME}
-    PRIVATE ${COMPILE_DEFINES_LIST}
-)
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE ${COMPILE_DEFINES_LIST}
+    )
+else()
+    message(STATUS "No configuration file given.")
+endif()
 
 if(PARABOLIC)
+  message(STATUS "Building Prandtl for: Compressible Navier-Stokes equations")
   target_compile_definitions(${PROJECT_NAME} PRIVATE PARABOLIC)
+else()
+  message(STATUS "Building Prandtl for: Euler equations")
 endif()
 
 if(SUBCELL_FV_BLENDING)
+  message(STATUS "Building Prandtl with: Subcell FV Blending enabled")
   target_compile_definitions(${PROJECT_NAME} PRIVATE SUBCELL_FV_BLENDING)
+endif()
+
+if(AXISYMMETRIC)
+  message(STATUS "Building Prandtl with: Axisymmetric domain enabled")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE AXISYMMETRIC)
 endif()
 
 target_sources(${PROJECT_NAME}

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -124,14 +124,14 @@ Discussion/question points are tagged `[Q1]`, `[Q2]`, etc, and link to the
 
 ### Steps
 - **Development process**
-  - [ ] Create Issue for Track B Phase 1  
-  - [ ] Create top-level branch for device-readiness  
-  - [ ] Draft PR closing the Issue  
+  - [x] Create Issue for Track B Phase 1  
+  - [x] Create top-level branch for device-readiness  
+  - [x] Draft PR closing the Issue  
 
 - **Centralize and abstract state layout** [`[Q1]`](#q1--state-layout-stability-high-priority-before-development)
-  - [ ] Add unit tests for state
-  - [ ] Add accessors for all state components  
-  - [ ] Ensure layout supports future scalar transport `[c:A]`  
+  - [x] Add unit tests for state
+  - [x] Add accessors for all state components  
+  - [x] Ensure layout supports future scalar transport `[c:A]`  
   - [ ] Plan for persistent primitive/derived states [`[Q2]`](#q2--persistent-state-requirements)
 
 - [ ] **Make `DGSEMOperator` a thin MFEM `TimeDependentOperator`**

--- a/src/Physics/GasState.hpp
+++ b/src/Physics/GasState.hpp
@@ -1,0 +1,338 @@
+#pragma once
+#include <cassert>
+// StateLayout and State Views for Gas Simulations
+//
+// Goal:
+//   - Centralize the mapping from (equation, dof) -> flat index
+//   - Provide simple per-DOF view for immediate refactoring
+//   - Provide general field-level view for future use
+//
+// Layout assumption (canonical, matches current code):
+// Note that potentially we change rho --> rho*Y_alpha.
+//   U(eq, dof) is currently stored as equation-blocked:
+//       U = [ rho       (block 0)
+//           | rho*u_x   (block 1)
+//           | rho*u_y   (block 2, if dim > 1)
+//           | rho*u_z   (block 3, if dim > 2)
+//           | rho*E     (block dim+1)
+//           | scalars (maybe/future, blocks dim+2:nspecies+dim+1) ]
+//
+// Each block has length = num_dofs_scalar.
+//
+// Notes:
+//   - DofStateView        : per-DOF view, simple and minimal, for refactors.
+//   - FieldStateView      : field-level view (full vector), forward-looking.
+//
+// Refactoring plan:
+//
+//   1) Replace raw indexing with DofStateView first.
+//   2) Introduce FieldStateView in loops or where convenient/needed.
+//   3) Extend StateLayout with scalars/species, without touching callers.
+//
+#include "mfem.hpp"
+
+namespace Prandtl
+{
+  using real_t = mfem::real_t;
+  // -----------------------------------------------------------------------------
+  // StateLayout: single point to define how state storage is arranged
+  // -----------------------------------------------------------------------------
+  
+  struct StateLayout
+  {
+    int dim;              // spatial dimension (1,2,3)
+    int num_dofs_scalar;  // DOFs per scalar field (block length)
+
+    // Equation indices (0-based)
+    int eq_mass;          // mass density
+    int eq_mom[3];        // momentum density components: x,y,z
+    int eq_energy;        // total energy density
+
+    // Optional scalar support (forward-looking)
+    int eq_scalar0;       // index of first scalar component (or -1 if none)
+    int num_scalars;      // number of scalar components
+
+    MFEM_HOST_DEVICE
+    StateLayout()
+      : dim(0),
+        num_dofs_scalar(0),
+        eq_mass(0),
+        eq_energy(0),
+        eq_scalar0(-1),
+        num_scalars(0)
+    {
+      eq_mom[0] = eq_mom[1] = eq_mom[2] = -1;
+    }
+
+    // Canonical ordering:
+    //   [rho, rho*u_0,-, rho*u_(dim-1), rho*E, scalars-]
+    MFEM_HOST_DEVICE
+    StateLayout(int dim_,
+                int num_dofs_scalar_,
+                int num_scalars_ = 0)
+      : dim(dim_),
+        num_dofs_scalar(num_dofs_scalar_),
+        eq_mass(0),
+        eq_energy(dim_ + 1),
+        eq_scalar0(num_scalars_ > 0 ? (dim_ + 2) : -1),
+        num_scalars(num_scalars_)
+    {
+      // Momentum components follow mass
+      for (int d = 0; d < 3; ++d)
+        {
+          eq_mom[d] = (d < dim_) ? (1 + d) : -1;
+        }
+    }
+    
+    /**
+     * Set up after creation.
+     *
+     * This method exists to allow default construction of StateLayout objects,
+     * which is sometimes required for use in containers (e.g., std::vector),
+     * serialization frameworks, or APIs that require default-constructible types.
+     * In such cases, the object is first default-constructed and then initialized
+     * via this setup() method.
+     *
+     * Prefer using the parameterized constructor whenever possible to ensure
+     * objects are fully initialized at construction time. Use setup() only when
+     * default construction is unavoidable due to external constraints.
+     *
+     * @param dim_             Spatial dimension (1, 2, or 3)
+     * @param num_dofs_scalar_ Number of DOFs per scalar field
+     * @param num_scalars_     Number of scalar components (default: 0)
+     */
+    MFEM_HOST_DEVICE void setup(int dim_, int num_dofs_scalar_, int num_scalars_ = 0)
+    {
+      dim = dim_;
+      num_dofs_scalar = num_dofs_scalar_;
+      eq_mass = 0;
+      eq_energy = dim_ + 1;
+      eq_scalar0 = (num_scalars_ > 0 ? (dim_ + 2) : -1);
+      num_scalars = num_scalars_;
+      // Momentum components follow mass
+      for (int d = 0; d < 3; ++d)
+        {
+          eq_mom[d] = (d < dim_) ? (1 + d) : -1;
+        }
+    }
+    // Convenience for nequations
+    MFEM_HOST_DEVICE inline int nequations() const
+    { return dim + 2 + num_scalars; }
+
+    // parameter validation routine
+    MFEM_HOST_DEVICE inline int validate(int equation, int dof) const
+    {
+      return ((equation < nequations() && dof < num_dofs_scalar &&
+               equation > -1 && dof > -1) ? 0 : 1);
+    }
+
+    // Flat index into the equation-blocked vector
+    MFEM_HOST_DEVICE inline int index(int equation, int dof) const
+    {
+      assert(validate(equation, dof) == 0);
+      return equation * num_dofs_scalar + dof;
+    }
+  };
+  
+  // -----------------------------------------------------------------------------
+  // DofStateView: per-DOF view (immediate refactor tool).
+  //
+  // Usage pattern:
+  //
+  //   const double* U = sol->Read();
+  //   StateLayout layout(dim, num_dofs_scalar);
+  //   for (int i = 0; i < num_dofs_scalar; ++i) {
+  //       DofStateView<const double> S{U, &layout, i};
+  //       double rho  = S.mass();
+  //       double rhoU = S.momentum(0);
+  //       double E    = S.energy();
+  //   }
+  //
+  // This is a small, value-type-like view with correct indexing.
+  // -----------------------------------------------------------------------------
+  struct DofStateView
+  {
+    const real_t* U;           // pointer into equation-blocked storage
+    const StateLayout* L;      // layout metadata
+    int dof;                   // which DOF (0 .. num_dofs_scalar-1)
+    
+    MFEM_HOST_DEVICE
+    DofStateView()
+      : U(nullptr), L(nullptr), dof(0)
+    { }
+    
+    MFEM_HOST_DEVICE
+    DofStateView(const real_t* U_,
+                 const StateLayout* L_,
+                 int dof_)
+      : U(U_), L(L_), dof(dof_)
+    { }
+    
+    MFEM_HOST_DEVICE inline bool is_valid() const
+    {
+      return (U != nullptr) && (L != nullptr);
+    }
+    
+    // Mass / density
+    MFEM_HOST_DEVICE inline real_t mass() const
+    {
+      return U[ L->index(L->eq_mass, dof) ];
+    }
+    
+    // Momentum components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline real_t momentum(int d) const
+    {
+      assert(d < L->dim);
+      return U[ L->index(L->eq_mom[d], dof) ];
+    }
+    
+    MFEM_HOST_DEVICE inline real_t momentum_x() const
+    {
+      return momentum(0);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t momentum_y() const
+    {
+      return (L->dim > 1) ? momentum(1) : real_t(0);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t momentum_z() const
+    {
+      return (L->dim > 2) ? momentum(2) : real_t(0);
+    }
+    
+    // Velocity components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline real_t velocity(int d) const
+    {
+      return momentum(d) / mass();
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_x() const
+    {
+      return momentum_x() / mass();
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_y() const
+    {
+      return momentum_y() / mass();
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_z() const
+    {
+      return momentum_z() / mass();
+    }
+    
+    // Total energy
+    MFEM_HOST_DEVICE inline real_t energy() const
+    {
+      return U[ L->index(L->eq_energy, dof) ];
+    }
+    
+    // Scalar components, if present
+    MFEM_HOST_DEVICE inline real_t scalar(int k) const
+    {
+      assert(L->num_scalars > 0);
+      assert(k >= 0 && "Invalid scalar index");
+      return U[ L->index(L->eq_scalar0 + k, dof) ];
+    }
+  };
+  
+
+  // -----------------------------------------------------------------------------
+  // FieldStateView: Field-level view.
+  //
+  // Wraps a real_t* + StateLayout and provides equation-blocked access over all DOFs.
+  // For use in loops that already use (eq, i) patterns, or when needing more general
+  // mechanism than DofStateView.
+  // -----------------------------------------------------------------------------
+  struct FieldStateView
+  {
+    real_t* data;                // raw pointer to equation-blocked storage
+    const StateLayout* layout;   // layout metadata
+    
+    MFEM_HOST_DEVICE
+    FieldStateView()
+      : data(nullptr), layout(nullptr)
+    { }
+    
+    MFEM_HOST_DEVICE
+    FieldStateView(real_t* data_,
+                   const StateLayout* layout_)
+      : data(data_), layout(layout_)
+    { }
+    
+    MFEM_HOST_DEVICE inline bool is_valid() const
+    {
+      return (data != nullptr) && (layout != nullptr);
+    }
+    
+    // Generic access by (equation, dof)
+    MFEM_HOST_DEVICE inline real_t& u(int equation, int dof) const
+    {
+      return data[ layout->index(equation, dof) ];
+    }
+    
+    // Named accessors for convenience
+    MFEM_HOST_DEVICE inline real_t& mass(int dof) const
+    {
+      return u(layout->eq_mass, dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t& momentum(int component, int dof) const
+    {
+      return u(layout->eq_mom[component], dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t& momentum_x(int dof) const
+    {
+      return u(layout->eq_mom[0], dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t& momentum_y(int dof) const
+    {
+      return u(layout->eq_mom[1], dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t& momentum_z(int dof) const
+    {
+      return u(layout->eq_mom[2], dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity(int component, int dof) const
+    {
+      return momentum(component, dof) / mass(dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_x(int dof) const
+    {
+      return momentum_x(dof) / mass(dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_y(int dof) const
+    {
+      return momentum_y(dof) / mass(dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_z(int dof) const
+    {
+      return momentum_z(dof) / mass(dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t& energy(int dof) const
+    {
+      return u(layout->eq_energy, dof);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t& scalar(int k, int dof) const
+    {
+      assert(layout->num_scalars > 0);
+      assert(k >= 0 && "Invalid scalar index");
+      return u(layout->eq_scalar0 + k, dof);
+    }
+  };
+
+  inline int offset_mass   (const Prandtl::StateLayout &L) { return L.index(L.eq_mass,   0); }
+  inline int offset_momentum  (const Prandtl::StateLayout &L) { return L.index(L.eq_mom[0], 0); }
+  inline int offset_energy (const Prandtl::StateLayout &L) { return L.index(L.eq_energy, 0); }
+  inline int offset_scalars (const Prandtl::StateLayout &L) { return L.index(L.eq_scalar0, 0); };
+} // namespace Prandtl

--- a/src/Physics/Physics.hpp
+++ b/src/Physics/Physics.hpp
@@ -2,13 +2,18 @@
 
 #include "mfem.hpp"
 
+#ifndef MFEM_HOST_DEVICE
+#define MFEM_HOST_DEVICE
+#endif
+
 namespace Prandtl
 {
 
-using namespace mfem;
+  //using namespace mfem;
+  using real_t = mfem::real_t;
 
-struct PhysicsConstants
-{
+  struct PhysicsConstants
+  {
     const real_t gamma;
     const real_t gammaInverse;
     const real_t gammaP1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(state_tests
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/mfem
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/hypre/src/hypre/include
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/metis-5.1.0/include
+    PUBLIC ${PROJECT_SOURCE_DIR}/src/Physics
 )
 target_link_directories(state_tests
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/mfem

--- a/tests/gas_state_adapter.hpp
+++ b/tests/gas_state_adapter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <vector>
+#include <GasState.hpp>
+
+// Adapter that uses the new StateLayout + FieldStateView as a "state-like"
+// object compatible with run_basic_mass_momentum_energy_test.
+class GasStateSemanticsAdapter
+{
+public:
+    using real_t = Prandtl::real_t;
+
+    GasStateSemanticsAdapter(int dim, int num_dofs_scalar)
+        : layout_(dim, num_dofs_scalar),
+          data_((dim + 2 + layout_.num_scalars) * num_dofs_scalar),
+          view_(data_.data(), &layout_)
+    { }
+
+    // --- StateSemantics "contract" API ---
+
+    int dim() const      { return layout_.dim; }
+    int num_dofs() const { return layout_.num_dofs_scalar; }
+
+    // Getters
+    real_t mass(int i) const
+    {
+        return view_.mass(i);
+    }
+
+    real_t momentum(int d, int i) const
+    {
+        return view_.momentum(d, i);
+    }
+
+    real_t energy(int i) const
+    {
+        return view_.energy(i);
+    }
+
+    // Setters
+    void set_mass(int i, real_t rho)
+    {
+        view_.mass(i) = rho;
+    }
+
+    void set_momentum(int d, int i, real_t rho_u_d)
+    {
+        view_.momentum(d, i) = rho_u_d;
+    }
+
+    void set_energy(int i, real_t rhoE)
+    {
+        view_.energy(i) = rhoE;
+    }
+
+private:
+    Prandtl::StateLayout layout_;
+    std::vector<real_t> data_;
+    Prandtl::FieldStateView view_;
+};

--- a/tests/state_tests.cpp
+++ b/tests/state_tests.cpp
@@ -2,8 +2,12 @@
 #include "unit_test.hpp"
 #include "state_semantics.hpp"
 #include "legacy_state_adapter.hpp"
+#include "GasState.hpp"
+#include "gas_state_adapter.hpp"
 
-TEST(LegacyState_MassMomentumEnergy)
+using real_t = Prandtl::real_t;
+
+TEST(LegacyState_MassMomentumEnergy_2D)
 {
     const int dim   = 2;   // or test dim=3 in another test
     const int ndofs = 5;   // small number is fine
@@ -13,3 +17,227 @@ TEST(LegacyState_MassMomentumEnergy)
 
     return 0;
 }
+
+TEST(LegacyState_MassMomentumEnergy_3D)
+{
+    const int dim   = 3;   // or test dim=3 in another test
+    const int ndofs = 5;   // small number is fine
+
+    LegacyConservativeState state(dim, ndofs);
+    run_basic_mass_momentum_energy_test(state);
+
+    return 0;
+}
+
+TEST(GasState_MassMomentumEnergy_2D)
+{
+    const int dim   = 2;
+    const int ndofs = 5;
+
+    GasStateSemanticsAdapter state(dim, ndofs);
+    run_basic_mass_momentum_energy_test(state);
+
+    return 0;
+}
+
+TEST(GasState_MassMomentumEnergy_3D)
+{
+    const int dim   = 3;
+    const int ndofs = 5;
+
+    GasStateSemanticsAdapter state(dim, ndofs);
+    run_basic_mass_momentum_energy_test(state);
+
+    return 0;
+}
+
+TEST(StateLayout_Indexing_NoScalars_2D)
+{
+    const int dim   = 2;
+    const int ndofs = 5;
+
+    Prandtl::StateLayout layout(dim, ndofs);
+
+    // Basic metadata
+    EXPECT_CLOSE(layout.dim,             dim,     0.0);
+    EXPECT_CLOSE(layout.num_dofs_scalar, ndofs,   0.0);
+    EXPECT_CLOSE(layout.eq_mass,         0,       0.0);
+    EXPECT_CLOSE(layout.eq_mom[0],       1,       0.0);
+    EXPECT_CLOSE(layout.eq_mom[1],       2,       0.0);
+    EXPECT_CLOSE(layout.eq_mom[2],      -1,       0.0); // unused in 2D
+    EXPECT_CLOSE(layout.eq_energy,       dim+1,   0.0);
+    EXPECT_CLOSE(layout.eq_scalar0,     -1,       0.0);
+    EXPECT_CLOSE(layout.num_scalars,     0,       0.0);
+
+    // Flat index should be eq * ndofs + dof
+    const int num_eq = dim + 2; // rho + dim momenta + energy
+    for (int eq = 0; eq < num_eq; ++eq)
+    {
+        for (int i = 0; i < ndofs; ++i)
+        {
+            const int expected = eq * ndofs + i;
+            EXPECT_CLOSE(layout.index(eq, i), expected, 0.0);
+        }
+    }
+
+    return 0;
+}
+
+TEST(StateLayout_Indexing_WithScalars_3D)
+{
+    const int dim        = 3;
+    const int ndofs      = 4;
+    const int num_scalars = 2;
+
+    Prandtl::StateLayout layout(dim, ndofs, num_scalars);
+
+    EXPECT_CLOSE(layout.dim,             dim,                  0.0);
+    EXPECT_CLOSE(layout.num_dofs_scalar, ndofs,                0.0);
+    EXPECT_CLOSE(layout.eq_mass,         0,                    0.0);
+    EXPECT_CLOSE(layout.eq_mom[0],       1,                    0.0);
+    EXPECT_CLOSE(layout.eq_mom[1],       2,                    0.0);
+    EXPECT_CLOSE(layout.eq_mom[2],       3,                    0.0);
+    EXPECT_CLOSE(layout.eq_energy,       dim + 1,              0.0); // 4
+    EXPECT_CLOSE(layout.eq_scalar0,      dim + 2,              0.0); // 5
+    EXPECT_CLOSE(layout.num_scalars,     num_scalars,          0.0);
+
+    const int num_eq = dim + 2 + num_scalars; // rho, 3 mom, E, 2 scalars
+
+    for (int eq = 0; eq < num_eq; ++eq)
+    {
+        for (int i = 0; i < ndofs; ++i)
+        {
+            const int expected = eq * ndofs + i;
+            EXPECT_CLOSE(layout.index(eq, i), expected, 0.0);
+        }
+    }
+
+    // Specifically check scalar blocks start where we expect
+    for (int k = 0; k < num_scalars; ++k)
+    {
+        const int eq_scalar_k = layout.eq_scalar0 + k;
+        for (int i = 0; i < ndofs; ++i)
+        {
+            const int expected = eq_scalar_k * ndofs + i;
+            EXPECT_CLOSE(layout.index(eq_scalar_k, i), expected, 0.0);
+        }
+    }
+
+    return 0;
+}
+
+TEST(DofStateView_ReadsExpectedComponents)
+{
+    const int dim   = 3;
+    const int ndofs = 4;
+    const int nscalars = 2;
+
+    Prandtl::StateLayout layout(dim, ndofs, nscalars);
+    const int num_eq = dim + 2 + nscalars;             // rho, dim*mom, E, scalars
+
+    std::vector<real_t> U(num_eq * ndofs);
+
+    // Fill equation-blocked storage with a simple pattern:
+    //   U(eq, i) = 10*eq + i + 1.0
+    for (int eq = 0; eq < num_eq; ++eq)
+    {
+        for (int i = 0; i < ndofs; ++i)
+        {
+            U[eq * ndofs + i] = 10.0 * eq + i + 1;
+        }
+    }
+
+    for (int i = 0; i < ndofs; ++i)
+    {
+        Prandtl::DofStateView S{U.data(), &layout, i};
+
+        // Mass
+        EXPECT_EQ(S.mass(), 10.0 * layout.eq_mass + i + 1);
+
+        // Momentum components
+        for (int d = 0; d < dim; ++d)
+        {
+            const int eq_m = layout.eq_mom[d];
+            EXPECT_EQ(S.momentum(d), 10.0 * eq_m + i + 1);
+            if (d == 0){
+              EXPECT_EQ(S.momentum_x(), S.momentum(d));
+            }
+            if (d == 1){
+              EXPECT_EQ(S.momentum_y(), S.momentum(d));
+            }
+            if (d == 2){
+              EXPECT_EQ(S.momentum_z(), S.momentum(d));
+            }
+        }
+
+        // Velocity components
+        for (int d = 0; d < dim; ++d)
+        {
+          const int eq_m = layout.eq_mom[d];
+          EXPECT_CLOSE(S.velocity(d),(10.0*eq_m+i+1)/(i+1), 1e-14);
+          if (d == 0){
+            EXPECT_EQ(S.velocity_x(), S.velocity(d));
+          }
+          if (d == 1){
+            EXPECT_EQ(S.velocity_y(), S.velocity(d));
+          }
+          if (d == 2){
+            EXPECT_EQ(S.velocity_z(), S.velocity(d));
+          }
+        }
+        
+        // Energy
+        EXPECT_CLOSE(S.energy(), 10.0 * layout.eq_energy + i + 1, 1e-14);
+        
+        // Scalars
+        for(int s = 0; s < nscalars; s++){
+          const int eq_s = layout.eq_scalar0;
+          EXPECT_EQ(S.scalar(s),10.0*(eq_s+s) + i + 1);
+        }
+    }
+    
+    return 0;
+}
+
+TEST(FieldStateView_ReadWriteRoundTrip)
+{
+    const int dim        = 3;
+    const int ndofs      = 3;
+    const int num_scalars = 2;
+
+    Prandtl::StateLayout layout(dim, ndofs, num_scalars);
+    const int num_eq = dim + 2 + num_scalars;
+
+    std::vector<real_t> U(num_eq * ndofs, 0.0);
+    Prandtl::FieldStateView S{U.data(), &layout};
+
+    // Write using named accessors
+    for (int i = 0; i < ndofs; ++i)
+    {
+        S.mass(i)       = 1.0 + i;
+        S.momentum_x(i) = 2.0 + i;
+        S.momentum_y(i) = 3.0 + i;
+        S.momentum_z(i) = 4.0 + i;
+        S.energy(i)     = 5.0 + i;
+        S.scalar(0, i)  = 6.0 + i;
+        S.scalar(1, i)  = 7.0 + i;
+    }
+
+    // Read back
+    for (int i = 0; i < ndofs; ++i)
+    {
+      EXPECT_EQ(S.mass(i),       1.0 + i);
+      EXPECT_EQ(S.momentum_x(i), 2.0 + i);
+      EXPECT_EQ(S.momentum_y(i), 3.0 + i);
+      EXPECT_EQ(S.momentum_z(i), 4.0 + i);
+      EXPECT_EQ(S.energy(i),     5.0 + i);
+      EXPECT_EQ(S.scalar(0, i),  6.0 + i);
+      EXPECT_EQ(S.scalar(1, i),  7.0 + i);
+      EXPECT_CLOSE(S.velocity_x(i), (2.0 + i)/(1.0 + i), 1e-16);
+      EXPECT_CLOSE(S.velocity_y(i), (3.0 + i)/(1.0 + i), 1e-16);
+      EXPECT_CLOSE(S.velocity_z(i), (4.0 + i)/(1.0 + i), 1e-16);
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
## Pull request overview

This PR introduces a centralized state layout abstraction and accessor API for gas simulation state data, providing a foundation for device-readiness and future scalar transport support. The implementation adds StateLayout, DofStateView, and FieldStateView classes to encapsulate equation-blocked storage patterns and provides comprehensive unit tests validating the new abstractions against existing legacy implementations.

**Key Changes:**
- Introduced `GasState.hpp` with StateLayout, DofStateView, and FieldStateView abstractions to centralize state storage mapping
- Added comprehensive unit tests covering 2D/3D configurations, with and without scalars, for both legacy and new state implementations
- Updated build configuration to support AXISYMMETRIC option and improved CONFIG_FILE handling

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| `src/Physics/GasState.hpp` | New header defining StateLayout metadata structure and DofStateView/FieldStateView accessors for equation-blocked state storage with support for mass, momentum, energy, and optional scalar fields |
| `tests/state_tests.cpp` | Added 7 new unit tests covering legacy and new state implementations in 2D/3D, layout indexing with/without scalars, and view accessor validation |
| `tests/gas_state_adapter.hpp` | New adapter implementing StateSemantics interface using the new GasState abstractions, enabling compatibility testing with existing test infrastructure |
| `tests/CMakeLists.txt` | Added include path for Physics directory to enable test compilation against new GasState.hpp |
| `src/Physics/Physics.hpp` | Added MFEM_HOST_DEVICE macro definition guard and switched from namespace import to explicit type alias |
| `CMakeLists.txt` | Added AXISYMMETRIC build option and improved CONFIG_FILE handling to gracefully handle empty configuration |
| `DEVELOPMENT_PLAN.md` | Marked Track B Phase 1 tasks as complete (state abstraction and unit tests) |
</details>

##### copilot-generated