### PR TITLE
Make gas model kernel friendly POD 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC ${CMAKE_SOURCE_DIR}/libs/metis-5.1.0/include
     PUBLIC ${CMAKE_SOURCE_DIR}/src/Operators/NonlinearForm
     PUBLIC ${CMAKE_SOURCE_DIR}/src/Operators
+    PUBLIC ${CMAKE_SOURCE_DIR}/src/Device
     PUBLIC ${CMAKE_SOURCE_DIR}/src/RiemannSolvers
     PUBLIC ${CMAKE_SOURCE_DIR}/src/BasicOperations
     PUBLIC ${CMAKE_SOURCE_DIR}/src/Filters

--- a/src/Device/Kernels.hpp
+++ b/src/Device/Kernels.hpp
@@ -1,0 +1,19 @@
+#pragma once
+// Drag in essential parts of MFEM for kernels
+#include "config/config.hpp"
+#include "general/forall.hpp"
+#ifndef MFEM_HOST_DEVICE
+#include "general/device.hpp"
+#endif
+#ifndef MFEM_HOST_DEVICE
+#error "MFEM_HOST_DEVICE not defined. Check MFEM headers/includes."
+#endif
+
+namespace Prandtl
+{
+#ifdef MFEM_USE_SINGLE
+  using real_t = float;
+#else
+  using real_t = double;
+#endif
+}

--- a/src/Physics/EOS.hpp
+++ b/src/Physics/EOS.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mfem.hpp"
+#include <cmath>
 #include "Physics.hpp"
 #include "GasState.hpp"
 
@@ -12,39 +12,41 @@ namespace Prandtl
 // ============================================================================
   struct IdealSingleGasEOS
   {
-    std::shared_ptr<const PhysicsConstants> phys;
-    
-    MFEM_HOST_DEVICE
-    explicit IdealSingleGasEOS(std::shared_ptr<const PhysicsConstants> pc)
-      : phys(std::move(pc))
-    { }
-
     // ---- helpers on conservative state --------------------------------------
-
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t density(const StateView &S) const
+    inline real_t R_gas(const PhysicsConstants &phys, const StateLayout &L,
+                        const StateView &S) const
     {
-        return S.mass(); // this is "rho" (mass density)
+      return phys.R_gas;
+    }
+ 
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t density(const PhysicsConstants &phys, const StateLayout &L,
+                          const StateView &S) const
+    {
+        return S.mass(L); // this is "rho" (mass density)
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t rhoE(const StateView &S) const
+    inline real_t rhoE(const PhysicsConstants &phys, const StateLayout &L,
+                       const StateView &S) const
     {
-        // rho*E
-        return S.energy();
+        return S.energy(L);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t momentum_sq(const StateView &S) const
+    inline real_t momentum_sq(const PhysicsConstants &phys, const StateLayout &L,
+                              const StateView &S) const
     {
-        const int dim = S.L->dim;   // uses state layout
+        const int dim = L.dim;   // uses state layout
         real_t m2 = 0;
         for (int d = 0; d < dim; ++d)
         {
-          const real_t m = S.momentum(d);
+          const real_t m = S.momentum(L,d);
           m2 += m * m;
         }
         return m2;
@@ -52,62 +54,86 @@ namespace Prandtl
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t kinetic_energy_density(const StateView &S) const
+    inline real_t kinetic_energy_density(const PhysicsConstants &phys, const StateLayout &L,
+                                         const StateView &S) const
     {
-        // 0.5 * rho * |u|^2 = 0.5 * |rho*u|^2 / rho
-        const real_t rho  = density(S);
-        const real_t m2   = momentum_sq(S);
-        return 0.5 * m2 / rho;
+      // 0.5 * rho * |u|^2 = 0.5 * |rho*u|^2 / rho
+      const real_t rho  = density(phys, L, S);
+      const real_t m2   = momentum_sq(phys, L, S);
+      return 0.5 * m2 / rho;
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t internal_energy_density(const StateView &S) const
+    inline real_t internal_energy_density(const PhysicsConstants &phys, const StateLayout &L,
+                                          const StateView &S) const
+    {
+      // rho*e = rho*E - 0.5*rho*|u|^2
+      return rhoE(phys, L, S) - kinetic_energy_density(phys, L, S);
+    }
+
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t internal_energy_from_pressure(const PhysicsConstants &phys, const StateLayout &L,
+                                                const StateView &S, real_t pressure) const
     {
         // rho*e = rho*E - 0.5*rho*|u|^2
-        return rhoE(S) - kinetic_energy_density(S);
+      return pressure / (phys.gamma - 1.0);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t specific_internal_energy(const StateView &S) const
+    inline real_t specific_internal_energy(const PhysicsConstants &phys, const StateLayout &L,
+                                           const StateView &S) const
     {
         // e = (rho*e) / rho
-        const real_t rho  = density(S);
-        const real_t rhoe = internal_energy_density(S);
-        return rhoe / rho;
+      const real_t rho  = density(phys, L, S);
+      const real_t rhoe = internal_energy_density(phys, L, S);
+      return rhoe / rho;
     }
 
     // ---- primary EOS interface ----------------------------------------------
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t pressure(const StateView &S) const
+    inline real_t pressure(const PhysicsConstants &phys, const StateLayout &L,
+                           const StateView &S) const
     {
-        // p = (gamma - 1) * (rho*E - 0.5*|rho*u|^2 / rho)
-        const real_t rhoe = internal_energy_density(S);
-        return phys->gammaM1 * rhoe;
+      // p = (gamma - 1) * (rho*E - 0.5*|rho*u|^2 / rho)
+      const real_t rhoe = internal_energy_density(phys, L, S);
+      return phys.gammaM1 * rhoe;
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t temperature(const StateView &S) const
+    inline real_t gamma(const PhysicsConstants &phys, const StateLayout &L,
+                        const StateView &S) const
     {
-        // p = rho*R*T  =>  T = p / (rho*R)
-        const real_t rho = density(S);
-        const real_t p   = pressure(S);
-        return p / (rho * phys->R_gas);
+      return phys.gamma;
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline void grad_temperature(const int dim, const StateView &S, const real_t *grad_rho,
-                          const real_t *grad_p, real_t *grad_t) const
+    inline real_t temperature(const PhysicsConstants &phys, const StateLayout &L,
+                              const StateView &S) const
     {
-      const real_t rho = density(S);
-      const real_t pressor = pressure(S)/rho;
-      const real_t cv = cp(S)/phys->gamma;
-      const real_t fac = phys->gammaM1Inverse/(cv*rho);
+      // p = rho*R*T  =>  T = p / (rho*R)
+      const real_t rho = density(phys, L, S);
+      const real_t p   = pressure(phys, L, S);
+      return p / (rho * phys.R_gas);
+    }
+
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline void grad_temperature(const PhysicsConstants &phys, const StateLayout  &L,
+                                 const StateView &S, const real_t *grad_rho,
+                                 const real_t *grad_p, real_t *grad_t) const
+    {
+      const int dim = L.dim;
+      const real_t rho = density(phys, L, S);
+      const real_t pressor = pressure(phys, L, S)/rho;
+      const real_t cv = cp(phys, L, S)/phys.gamma;
+      const real_t fac = phys.gammaM1Inverse/(cv*rho);
       for(int i = 0; i < dim; i++){
         grad_t[i] = fac*(grad_p[i] - pressor*grad_rho[i]);
       }
@@ -115,35 +141,130 @@ namespace Prandtl
 
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t sound_speed(const StateView &S) const
+    inline real_t sound_speed(const PhysicsConstants &phys, const StateLayout &L,
+                              const StateView &S) const
     {
-        // a^2 = gamma * p / rho
-        const real_t rho = density(S);
-        const real_t p   = pressure(S);
-        return std::sqrt(phys->gamma * p / rho);
+      // a^2 = gamma * p / rho
+      const real_t rho = density(phys, L, S);
+      const real_t p   = pressure(phys, L, S);
+      return std::sqrt(phys.gamma * p / rho);
     }
-
+    
     // cp is constant for ideal gas
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline real_t cp(const StateView & /*S*/) const
+    inline real_t cp(const PhysicsConstants &phys, const StateLayout &L,
+                     const StateView & /*S*/) const
     {
-        return phys->cp;
+        return phys.cp;
+    }
+
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t entropy(const PhysicsConstants &phys, const StateLayout &L,
+                          const StateView &S) const
+    {
+      const real_t p = pressure(phys, L, S);
+      const real_t gamma = phys.gamma;
+      // TODO: Augment for correct treatment of passive scalars
+      return std::log(p) - gamma * std::log(S.mass(L));
+    }
+
+    template<typename InStateView, typename OutStateView>
+    MFEM_HOST_DEVICE
+    inline void entropy_state(const PhysicsConstants &phys, const StateLayout &L,
+                              const InStateView &S, OutStateView &E) const
+    {
+      const real_t p = pressure(phys, L, S);
+      const real_t gamma = phys.gamma;
+      const real_t rho = S.mass(L);
+      const real_t s = std::log(p) - gamma*std::log(rho);
+      const real_t beta = rho / p;
+      const real_t v2o2 = kinetic_energy_density(phys, L, S) / rho;
+      const real_t s_rho = (gamma - s)/(gamma - 1) - beta*v2o2;
+
+      E.set_mass(L, s_rho);
+      int dim = L.dim;
+      int num_scalars = L.num_scalars;
+      for(int idim = 0;idim < dim;idim++){
+        E.set_momentum(L, idim, beta * S.velocity(L, idim));
+      }
+      E.set_energy(L, -beta);
+      // TODO: Update for correct treatment of passive scalars (depends on ES approach)
+      // - Here we should probably set the entropy state to scalar_state / density
+      // - If we do that, we need to modify the mass component of the entropy state
+      // - Making this fix will make the sensor function sensitive to the scalars
+      // - If we need to recover CV from this, lax scalar treatment is a nogo
+      for(int iscalar = 0;iscalar < num_scalars;iscalar++){
+        E.set_scalar(L, iscalar, 0.0);
+      }
+    }
+
+    template<typename InStateView, typename OutStateView>
+    MFEM_HOST_DEVICE
+    inline void grad_entropy_to_grad_prim(const PhysicsConstants &phys, const StateLayout &L,
+                                          const InStateView &S, const InStateView &dE,
+                                          OutStateView &dPrim) const
+    {
+
+      const real_t ke = kinetic_energy_density(phys, L, S);
+      const real_t p = pressure(phys, L, S);
+      const real_t rho = S.mass(L);
+      const real_t rhoE = S.energy(L);
+      const real_t ie = internal_energy_density(phys, L, S);
+
+      int dim = L.dim;
+      int num_scalars = L.num_scalars;
+
+      real_t drho = 0.0;
+      for(int idim = 0; idim < dim; idim++){
+        dPrim.set_momentum(L, idim, p/rho * (dE.momentum(L, idim) + S.velocity(L, idim)*dE.energy(L)));
+        drho += S.momentum(L, idim)*dPrim.momentum(L, idim);
+      }
+      drho = rho*dE.mass(L) - dE.energy(L)*(ke - ie) + rho*drho/p;
+      dPrim.set_mass(L, drho);
+      dPrim.set_energy(L, p/rho * (dPrim.mass(L) + p*dE.energy(L)));
+      for(int isp = 0; isp < num_scalars; isp++){
+        dPrim.set_scalar(L, isp, 0.0); // just a placeholder for now
+      }
+    }
+
+    template<typename InStateView, typename OutStateView>
+    MFEM_HOST_DEVICE
+    inline void entropy_to_conserved(const PhysicsConstants &phys, const StateLayout &L,
+                                     const InStateView &Se, OutStateView &Sc) const
+    {
+      int dim = L.dim;
+      const real_t beta = -Se.energy(L);
+      real_t k = 0.0;
+      real_t vel[3];
+      for(int idim = 0;idim < dim;idim++){
+        vel[idim] = Se.momentum(L, idim)/beta;
+        k += vel[idim]*vel[idim];
+      }
+      const real_t gamma = phys.gamma;
+      const real_t s = gamma - (Se.mass(L) + 0.5*k*beta)*(gamma - 1.);
+      const real_t rho = std::pow(std::exp(-s)/beta, 1.0/(gamma - 1));
+      Sc.set_mass(L, rho);
+      Sc.set_energy(L, rho*(1.0/(beta*(gamma-1.)) + 0.5*k));
+      for(int idim = 0;idim < dim;idim++){
+        Sc.set_momentum(L, idim, rho*vel[idim]);
+      }
     }
 
     // TODO: Consider whether this is needed/convenient
     // It *can be* nice to have here, but kind of out-of-place
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline void velocity(const StateView &S, real_t u[3]) const
+    inline void velocity(const PhysicsConstants &phys, const StateLayout &L,
+                         const StateView &S, real_t u[3]) const
     {
-        const real_t rho = density(S);
-        const int dim = S.L->dim;
-        for (int d = 0; d < dim; ++d)
+      const int dim = L.dim;
+      for (int d = 0; d < dim; ++d)
         {
-            u[d] = S.momentum(d) / rho;
+          u[d] = S.velocity(L, d);
         }
-        for (int d = dim; d < 3; ++d)
+      for (int d = dim; d < 3; ++d)
         {
           u[d] = real_t(0);
         }

--- a/src/Physics/Flow.hpp
+++ b/src/Physics/Flow.hpp
@@ -1,0 +1,179 @@
+#pragma once
+#include <cassert>
+#include <cmath>
+#include "GasModel.hpp"
+// This file contains helper routines that implement flow physics models
+// and methods. Helpers in this module need and use results from the gas
+// EOS and Transport models, but do not belong themselves in the EOS or
+// Transport constructs.
+//
+// NOTE: The main reason for existence of these helpers is to centralize
+// the routines which may need to be updated when adding new gas models
+// like LTE/NLTE. Some routines in this module may be invalid for other
+// gas types, but are central to how fluxes are computed.
+namespace Prandtl {
+  namespace Flow {
+
+    // This routine takes as input a  *face-oriented* state as input and returns
+    // p* for the 1D Riemann problem at the face. 
+    template<typename StateView, typename GasModelT>
+    MFEM_HOST_DEVICE
+    inline real_t slipwall_pstar(const StateView &S, const GasModelT &gasModel)
+    {
+      const real_t rho = gasModel.density(S);
+      const real_t c = gasModel.sound_speed(S);
+      const real_t p = gasModel.pressure(S);
+      const real_t v = gasModel.velocity(S, 0);
+      const real_t gamma = gasModel.gamma(S);
+      const real_t gammaP1 = gamma + 1.;
+      const real_t gammaM1 = gamma - 1.;
+      const real_t gammaP1Inverse = 1.0/gammaP1;
+      const real_t gammaM1Inverse = 1.0/gammaM1;
+      if (v > 0.0){
+        return (p + 0.25*v*gammaP1*rho*
+                (v + std::sqrt(v*v + 8.0*gammaP1Inverse*p*(gammaM1*gammaP1Inverse+1.0)/rho)));
+      } else {
+        return p * std::pow(std::max(1.0 + 0.5*gammaM1*v/c, 0.0001), 2.0*gamma*gammaM1Inverse);
+      }
+      return 0.0;
+    }
+
+    // This interface uses the internal entropy state (Se), and the wall temp (Tw) to get a "wall beta"
+    // It *requires specialization* for any gas other than ideal single component gas
+    // Ideal Gas: beta = 1/(RTwall)
+    // Ideal Mixtures / LTE beta = 1/(Rmix*Twall), where Rmix is depending on the mixture Rmix(Y)
+    // NLTE: Potentially this will be OK, but EOS-dependent
+    template<typename StateView, typename GasModelT>
+    MFEM_HOST_DEVICE
+    inline real_t isothermal_wall_beta(const StateView &Se, real_t Tw, const GasModelT &gasModel)
+    {
+      // In gas models where R_gas is not constant (e.g. a mixture), we need to pass the *conserved*
+      // state to the gasModel.R_gas function. Since we only have ideal atm with fixed R_gas, I am
+      // skipping the unnecessary Entropy2Conservative conversion.  
+      return (1.0 / (gasModel.R_gas(Se)*Tw));
+    }
+
+    struct TotalConditions {
+      real_t p0;
+      real_t T0;
+    };
+
+    struct StaticKinematics {
+      real_t rho;
+      real_t v2;
+      real_t energy;
+    };
+
+    template<typename ConservedStateView, typename GasModelT>
+    MFEM_HOST_DEVICE
+    inline StaticKinematics isentropic_total_to_static(const ConservedStateView &S, const TotalConditions &Ct,
+                                                       const GasModelT &gasModel)
+    {
+      StaticKinematics out{};
+      const real_t p = gasModel.pressure(S);
+      const real_t gamma = gasModel.gamma(S);
+      const real_t cp = gasModel.cp(S);
+      const real_t gm1 = gamma - 1.0;
+      const real_t expo = gm1 / gamma;
+
+      real_t v2 = 2.0*cp*Ct.T0*(1.0 - std::pow(p/Ct.p0, expo));
+      v2 = std::max(0.0, v2);
+      const real_t cpT = cp * Ct.T0 - 0.5*v2;
+      out.rho = (gamma / gm1)*p/cpT;
+      out.energy = p/gm1 + 0.5*v2*out.rho;
+      return out;
+    }
+
+    template<typename StateView, typename StateViewRW, typename GasModelT>
+    MFEM_HOST_DEVICE
+    inline void riemann_invariant_outer_state(const StateView &Si, const StateView &So, StateViewRW &S2, const real_t *n,
+                                              const GasModelT &gasModel)
+    {
+      const int dim = gasModel.dim();
+      const real_t rho_i = gasModel.density(Si);
+      const real_t rho_o = gasModel.density(So);
+      real_t Vn_i = gasModel.momentum(Si, 0)*n[0];
+      real_t Vn_o = gasModel.momentum(So, 0)*n[0];
+      if (dim > 1){
+        Vn_i += gasModel.momentum(Si, 1)*n[1];
+        Vn_o += gasModel.momentum(So, 1)*n[1];
+      }
+      if (dim > 2){
+        Vn_i += gasModel.momentum(Si, 2)*n[2];
+        Vn_o += gasModel.momentum(So, 2)*n[2];
+      }
+
+      Vn_i /= rho_i;
+      Vn_o /= rho_o;
+
+      const real_t p_i = gasModel.pressure(Si);
+      const real_t a_i = gasModel.sound_speed(Si);
+      const real_t p_o = gasModel.pressure(So);
+      const real_t a_o = gasModel.sound_speed(So);
+
+      const real_t gamma = gasModel.gamma(Si);
+      const real_t gm1 = gamma - 1.0;
+      const real_t gm1i = 1.0 / gm1;
+      const real_t gi = 1.0/gamma;
+
+      const bool ext_supersonic_n = (std::abs(Vn_o) >= a_o);
+
+      const real_t Rm =
+        (ext_supersonic_n && Vn_i >= 0.0)
+        ? (Vn_i - 2.0 * a_i * gm1i)
+        : (Vn_o - 2.0 * a_o * gm1i);      
+      const real_t Rp =
+        (ext_supersonic_n && Vn_i < 0.0)
+        ? (Vn_o + 2.0 * a_o * gm1i)
+        : (Vn_i + 2.0 * a_i * gm1i);
+
+      const real_t Vn_b = 0.5 * (Rm + Rp);
+      const real_t a_b = 0.25*gm1*(Rp - Rm);
+
+      const real_t dVn_i = Vn_b - Vn_i;
+      const real_t dVn_o = Vn_b - Vn_o;
+
+      // Density from isentrope anchored on inflow/outflow side
+      const auto rho_from_ref = [&](real_t rho_ref, real_t p_ref) {
+        // rho_b = rho_ref * ( (a_b^2 * rho_ref)/(gamma*p_ref) )^(1/(gamma-1))
+        const real_t factor = (a_b*a_b) * rho_ref / (gamma * p_ref);
+        return rho_ref * std::pow(factor, gm1i);
+      };
+
+      const bool inflow = (Vn_i < 0.0);
+      const real_t rho_b = inflow ? rho_from_ref(rho_o, p_o) : rho_from_ref(rho_i, p_i);
+      S2.set_mass(gasModel.L, rho_b);
+      const real_t p_b = (a_b * a_b) * rho_b * gi;
+      real_t vb[3] = {0., 0., 0.};
+      real_t vb2 = 0.0;
+      const real_t dVn = inflow ? dVn_o : dVn_i;
+      for(int idim = 0;idim < dim;idim++){
+        const real_t base = inflow ? gasModel.velocity(So, idim) : gasModel.velocity(Si, idim);
+        vb[idim] = base + dVn*n[idim];
+        vb2 += (vb[idim]*vb[idim]);
+        S2.set_momentum(gasModel.L, idim, rho_b*vb[idim]);
+      }
+      S2.set_energy(gasModel.L, p_b * gm1i + 0.5 * rho_b * vb2);
+    }
+
+    template<typename PrimStateView, typename ConsStateView, typename GasModelT>
+    MFEM_HOST_DEVICE inline void PrimitiveToConserved(const PrimStateView &prim, ConsStateView &cons, const GasModelT &gasModel){
+      const real_t rho = prim.mass(gasModel.L);
+      const int dim = gasModel.dim();
+      // NOTE: This call *should* fail for gas models other than ideal single component
+      const real_t gamma = gasModel.gamma(prim);
+      real_t v2 = prim.velocity(gasModel.L, 0)*prim.velocity(gasModel.L, 0);
+      cons.set_mass(gasModel.L, rho);
+      cons.set_momentum(gasModel.L, 0, rho*prim.velocity(gasModel.L, 0));
+      if (dim > 1){
+        cons.set_momentum(gasModel.L, 1, rho*prim.velocity(gasModel.L, 1));
+        v2 += prim.velocity(gasModel.L, 1)*prim.velocity(gasModel.L, 1);
+      }
+      if (dim > 2){
+        cons.set_momentum(gasModel.L, 2, rho*prim.velocity(gasModel.L, 2));
+        v2 += prim.velocity(gasModel.L, 2)*prim.velocity(gasModel.L,2);
+      }
+      cons.set_energy(gasModel.L, prim.pressure(gasModel.L) / (gamma-1.) + 0.5 * rho * v2); 
+    }
+  }
+}

--- a/src/Physics/GasModel.hpp
+++ b/src/Physics/GasModel.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "mfem.hpp"
 #include "Physics.hpp"
 #include "GasState.hpp"
 #include "EOS.hpp"
@@ -12,99 +11,191 @@ namespace Prandtl
 // ============================================================================
 // GasModel: Encapsulate EOS/Transport
 // ============================================================================
-
   template <typename EOSImpl, typename TransportImpl>
   struct GasModel
   {
+
+    PhysicsConstants phys;
+    StateLayout L;
     EOSImpl eos;
     TransportImpl transport;
     
     MFEM_HOST_DEVICE
-    GasModel() = default;
-
-    MFEM_HOST_DEVICE
-    GasModel(const EOSImpl &eos_in, const TransportImpl &tr_in)
-        : eos(eos_in), transport(tr_in)
+    GasModel(const PhysicsConstants &phys_in, const StateLayout &L_in,
+             const EOSImpl &eos_in, const TransportImpl &tr_in)
+      : phys(phys_in), L(L_in), eos(eos_in), transport(tr_in)
     { }
 
     MFEM_HOST_DEVICE
-    explicit GasModel(std::shared_ptr<const PhysicsConstants> phys)
-        : eos(EOSImpl(phys)), transport(TransportImpl(phys))
+    GasModel(const PhysicsConstants &phys_in, const StateLayout &L_in)
+      : phys(phys_in), L(L_in)
     { }
+
+    // Utilities and constants etc
+    MFEM_HOST_DEVICE
+    inline int num_equations() const
+    { return L.nequations(); };
+
+    MFEM_HOST_DEVICE
+    inline int dim() const
+    { return L.dim; };
+
+    // State Access
+    MFEM_HOST_DEVICE
+    template<typename StateView>
+    inline real_t velocity(const StateView &S, int d) const
+    { return S.velocity(L,d);}
+
+    MFEM_HOST_DEVICE
+    template<typename StateView>
+    inline real_t momentum(const StateView &S, int d) const
+    { return S.momentum(L,d);}
+
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t density(const StateView &S) const
+    {
+      return eos.density(phys, L, S);
+    }
+
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t mass(const StateView &S) const
+    {
+      return eos.density(phys, L, S);
+    }
+
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t energy(const StateView &S) const
+    {
+      return S.energy(L);
+    }
 
     // --- Thermodynamics ------------------------------------------------------
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t pressure(const StateView &S) const
     {
-        return eos.pressure(S);
+      return eos.pressure(phys, L, S);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
+    inline real_t gamma(const StateView &S) const
+    {
+      return eos.gamma(phys, L, S);
+    }
+ 
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t cp(const StateView &S) const
+    {
+      return eos.cp(phys, L, S);
+    }
+    
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t R_gas(const StateView &S) const
+    {
+      return eos.R_gas(phys, L, S);
+    }
+ 
+    template<typename StateView>
+    MFEM_HOST_DEVICE
     inline real_t temperature(const StateView &S) const
     {
-        return eos.temperature(S);
+      return eos.temperature(phys, L, S);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t sound_speed(const StateView &S) const
     {
-        return eos.sound_speed(S);
-    }
-
-    template<typename StateView>
-    MFEM_HOST_DEVICE
-    inline real_t density(const StateView &S) const
-    {
-        return eos.density(S);
+      return eos.sound_speed(phys, L, S);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t kinetic_energy_density(const StateView &S) const
     {
-      return eos.kinetic_energy_density(S);
+      return eos.kinetic_energy_density(phys, L, S);
+    }
+
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t internal_energy_from_pressure(const StateView &S, real_t pressure) const
+    {
+        // rho*e = rho*E - 0.5*rho*|u|^2
+      return eos.internal_energy_from_pressure(phys, L, S, pressure);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t specific_internal_energy(const StateView &S) const
     {
-        return eos.specific_internal_energy(S);
+      return eos.specific_internal_energy(phys, L, S);
     }
-
+    
     template<typename StateView>
     MFEM_HOST_DEVICE
-    inline void grad_temperature(const int ndim, const StateView &S,
+    inline void grad_temperature(const StateView &S,
                                  const real_t *grad_r, const real_t *grad_p,
                                  real_t *grad_t) const
     {
-      return eos.grad_temperature(ndim, S, grad_r, grad_p, grad_t);
+      return eos.grad_temperature(phys, L, S, grad_r, grad_p, grad_t);
     }
  
+    template<typename StateView>
+    MFEM_HOST_DEVICE
+    inline real_t entropy(const StateView &S)
+    {
+      return eos.entropy(phys, L, S);
+    }
+
+    template<typename InStateView, typename OutStateView>
+    MFEM_HOST_DEVICE
+    inline void entropy_state(const InStateView &S, OutStateView &E) const
+    {
+      return eos.entropy_state(phys, L, S, E);
+    }
+
+    template<typename InStateView, typename OutStateView>
+    MFEM_HOST_DEVICE
+    inline void grad_entropy_to_grad_prim(const InStateView &S, const InStateView &dS,
+                                          OutStateView &dPrim) const
+    {
+      return eos.grad_entropy_to_grad_prim(phys, L, S, dS, dPrim);
+    }
+
+    template<typename InStateView, typename OutStateView>
+    MFEM_HOST_DEVICE
+    inline void entropy_to_conserved(const InStateView &Se, OutStateView &Sc) const
+    {
+      return eos.entropy_to_conserved(phys, L, Se, Sc);
+    }
+
     // --- Transport -----------------------------------------------------------
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t viscosity(const StateView &S) const
     {
-      return transport.viscosity(eos, S);
+      return transport.viscosity(phys, L, eos, S);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t bulk_viscosity(const StateView &S) const
     {
-      return transport.bulk_viscosity(eos, S);
+      return transport.bulk_viscosity(phys, L, eos, S);
     }
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t thermal_conductivity(const StateView &S) const
     {
-      return transport.thermal_conductivity(eos, S);
+      return transport.thermal_conductivity(phys, L, eos, S);
     }
   };
 
@@ -112,9 +203,9 @@ namespace Prandtl
   using IdealGasModel = GasModel<IdealSingleGasEOS, Transport>;
   
   // Bridge helper so old call-sites that only have PhysicsConstants can move over
-  inline IdealGasModel make_ideal_gas_model(std::shared_ptr<const PhysicsConstants> phys)
-  {
-    return IdealGasModel(phys);
-  }
+  // inline IdealGasModel make_ideal_gas_model(std::shared_ptr<const PhysicsConstants> phys)
+  // {
+  //   return IdealGasModel(phys);
+  // }
 
 } // namespace Prandtl

--- a/src/Physics/GasState.hpp
+++ b/src/Physics/GasState.hpp
@@ -4,11 +4,12 @@
 //
 // Goal:
 //   - Centralize the mapping from (equation, dof) -> flat index
-//   - Provide simple per-DOF view for immediate refactoring
+//   - Provide indices and offsets for accessing model-specific
+//     quantities from the solution data
 //   - Provide general field-level view for future use
 //
 // Layout assumption (canonical, matches current code):
-// Note that potentially we change rho --> rho*Y_alpha.
+// Note that potentially we will change rho --> rho*Y_alpha.
 //   U(eq, dof) is currently stored as equation-blocked:
 //       U = [ rho       (block 0)
 //           | rho*u_x   (block 1)
@@ -17,23 +18,12 @@
 //           | rho*E     (block dim+1)
 //           | scalars (maybe/future, blocks dim+2:nspecies+dim+1) ]
 //
-// Each block has length = num_dofs_scalar.
+// Each block has length = num_dofs_scalar (wrt mesh or element)
 //
-// Notes:
-//   - DofStateView        : per-DOF view, simple and minimal, for refactors.
-//   - FieldStateView      : field-level view (full vector), forward-looking.
-//
-// Refactoring plan:
-//
-//   1) Replace raw indexing with DofStateView first.
-//   2) Introduce FieldStateView in loops or where convenient/needed.
-//   3) Extend StateLayout with scalars/species, without touching callers.
-//
-#include "mfem.hpp"
+#include "Kernels.hpp"
 
 namespace Prandtl
 {
-  using real_t = mfem::real_t;
   // -----------------------------------------------------------------------------
   // StateLayout: single point to define how state storage is arranged
   // -----------------------------------------------------------------------------
@@ -45,44 +35,13 @@ namespace Prandtl
 
     // Equation indices (0-based)
     int eq_mass;          // mass density
+    int eq_mom0;          // first component of momentum
     int eq_mom[3];        // momentum density components: x,y,z
     int eq_energy;        // total energy density
 
     // Optional scalar support (forward-looking)
     int eq_scalar0;       // index of first scalar component (or -1 if none)
     int num_scalars;      // number of scalar components
-
-    MFEM_HOST_DEVICE
-    StateLayout()
-      : dim(0),
-        num_dofs_scalar(0),
-        eq_mass(0),
-        eq_energy(0),
-        eq_scalar0(-1),
-        num_scalars(0)
-    {
-      eq_mom[0] = eq_mom[1] = eq_mom[2] = -1;
-    }
-
-    // Canonical ordering:
-    //   [rho, rho*u_0,-, rho*u_(dim-1), rho*E, scalars-]
-    MFEM_HOST_DEVICE
-    StateLayout(int dim_,
-                int num_dofs_scalar_,
-                int num_scalars_ = 0)
-      : dim(dim_),
-        num_dofs_scalar(num_dofs_scalar_),
-        eq_mass(0),
-        eq_energy(dim_ + 1),
-        eq_scalar0(num_scalars_ > 0 ? (dim_ + 2) : -1),
-        num_scalars(num_scalars_)
-    {
-      // Momentum components follow mass
-      for (int d = 0; d < 3; ++d)
-        {
-          eq_mom[d] = (d < dim_) ? (1 + d) : -1;
-        }
-    }
     
     /**
      * Set up after creation.
@@ -101,7 +60,7 @@ namespace Prandtl
      * @param num_dofs_scalar_ Number of DOFs per scalar field
      * @param num_scalars_     Number of scalar components (default: 0)
      */
-    MFEM_HOST_DEVICE void setup(int dim_, int num_dofs_scalar_, int num_scalars_ = 0)
+    void setup(int dim_, int num_dofs_scalar_, int num_scalars_ = 0)
     {
       dim = dim_;
       num_dofs_scalar = num_dofs_scalar_;
@@ -110,11 +69,18 @@ namespace Prandtl
       eq_scalar0 = (num_scalars_ > 0 ? (dim_ + 2) : -1);
       num_scalars = num_scalars_;
       // Momentum components follow mass
+      eq_mom0 = 1;
       for (int d = 0; d < 3; ++d)
         {
           eq_mom[d] = (d < dim_) ? (1 + d) : -1;
         }
     }
+
+    // Canonical ordering:
+    //   [rho, rho*u_0,-, rho*u_(dim-1), rho*E, scalars-]
+    StateLayout(int dim_, int num_dofs_scalar_, int num_scalars_ = 0)
+    { setup(dim_, num_dofs_scalar_, num_scalars_);}
+
     // Convenience for nequations
     MFEM_HOST_DEVICE inline int nequations() const
     { return dim + 2 + num_scalars; }
@@ -140,116 +106,406 @@ namespace Prandtl
   // Usage pattern:
   //
   //   Vector state = [rho, rhoVx, rhoVy, rhoVz, rhoE]
-  //   PointStateView S{state.GetData(), &layout};
-  //   double rho = S.mass();
-  //   double rhoU = S.momentum(0);
-  //   double rhoE = S.energy();
+  //   const real_t *q = state.GetData();
+  //   PointStateView S{state.GetData()};
+  //   double rho = S.mass(layout);
+  //   double rhoU = S.momentum(layout, 0);
+  //   double rhoE = S.energy(layout);
+  //
+  //   double rho = q[layout.eq_mass];  (same thing)
+  //
   //
   // This is a small, value-type-like view with correct indexing.
   // -----------------------------------------------------------------------------
   struct PointStateView
   {
     const real_t* U;           // packed state data -> [rho, rhoVx, rhoVy, ..., rhoE]
-    const StateLayout* L;      // layout metadata
     
-    MFEM_HOST_DEVICE
-    PointStateView()
-      : U(nullptr), L(nullptr)
+    PointStateView(const real_t* U_)
+      : U(U_)
     { }
-    
-    MFEM_HOST_DEVICE
-    PointStateView(const real_t* U_,
-                   const StateLayout* L_)
-      : U(U_), L(L_)
-    { }
-    
+
     MFEM_HOST_DEVICE inline bool is_valid() const
     {
-      return (U != nullptr) && (L != nullptr);
+      return (U != nullptr);
     }
-    
+ 
     // Mass / density
-    MFEM_HOST_DEVICE inline real_t mass() const
+    MFEM_HOST_DEVICE inline real_t mass(const StateLayout &L) const
     {
-      const real_t rho = U[ L->eq_mass ];
+      const real_t rho = U[ L.eq_mass ];
       return rho;
     }
-    
-    // Momentum address
-    MFEM_HOST_DEVICE inline int momentum_eq() const
-    {
-      return L->eq_mom[0];
-    }
+ 
     // Momentum components: d = 0(x),1(y),2(z)
-    MFEM_HOST_DEVICE inline real_t momentum(int d) const
+    MFEM_HOST_DEVICE inline real_t momentum(const StateLayout &L, int d) const
     {
-      assert(d < L->dim);
-      return U[ L->eq_mom[d] ];
+      assert(d < L.dim);
+      return U[ L.eq_mom[d] ];
     }
     
-    MFEM_HOST_DEVICE inline real_t momentum_x() const
+    MFEM_HOST_DEVICE inline real_t momentum_x(const StateLayout &L) const
     {
-      return momentum(0);
+      return momentum(L, 0);
     }
     
-    MFEM_HOST_DEVICE inline real_t momentum_y() const
+    MFEM_HOST_DEVICE inline real_t momentum_y(const StateLayout &L) const
     {
-      return (L->dim > 1) ? momentum(1) : real_t(0);
+      return momentum(L, 1);
     }
     
-    MFEM_HOST_DEVICE inline real_t momentum_z() const
+    MFEM_HOST_DEVICE inline real_t momentum_z(const StateLayout &L) const
     {
-      return (L->dim > 2) ? momentum(2) : real_t(0);
+      return momentum(L, 2);
     }
     
     // Velocity components: d = 0(x),1(y),2(z)
-    MFEM_HOST_DEVICE inline real_t velocity(int d) const
+    MFEM_HOST_DEVICE inline real_t velocity(const StateLayout &L, int d) const
     {
-      return momentum(d) / mass();
+      return momentum(L, d) / mass(L);
     }
 
-    MFEM_HOST_DEVICE inline real_t velocity_x() const
+    MFEM_HOST_DEVICE inline real_t velocity_x(const StateLayout &L) const
     {
-      return momentum_x() / mass();
+      return momentum_x(L) / mass(L);
     }
 
-    MFEM_HOST_DEVICE inline real_t velocity_y() const
+    MFEM_HOST_DEVICE inline real_t velocity_y(const StateLayout &L) const
     {
-      return momentum_y() / mass();
+      return momentum_y(L) / mass(L);
     }
     
-    MFEM_HOST_DEVICE inline real_t velocity_z() const
+    MFEM_HOST_DEVICE inline real_t velocity_z(const StateLayout &L) const
     {
-      return momentum_z() / mass();
+      return momentum_z(L) / mass(L);
     }
     
     // Total energy
-    MFEM_HOST_DEVICE inline real_t energy() const
+    MFEM_HOST_DEVICE inline real_t energy(const StateLayout &L) const
     {
-      return U[ L->eq_energy ];
+      return U[ L.eq_energy ];
     }
     
     // Scalar components, if present
-    MFEM_HOST_DEVICE inline real_t scalar(int k) const
+    MFEM_HOST_DEVICE inline real_t scalar(const StateLayout &L, int k) const
     {
-      assert(L->num_scalars > 0);
-      assert((k >= 0 && k < L->num_scalars) && "Invalid scalar index");
-      return U[ L->eq_scalar0 + k ];
+      assert(L.num_scalars > 0);
+      assert((k >= 0 && k < L.num_scalars) && "Invalid scalar index");
+      return U[ L.eq_scalar0 + k ];
     }
   };
 
   // -----------------------------------------------------------------------------
-  // DofStateView: per-DOF view (immediate refactor tool).
+  // PointStateViewRW: *writeable* per-point view
+  //
+  // Usage pattern:
+  //
+  //   Vector state = [rho, rhoVx, rhoVy, rhoVz, rhoE]
+  //   PointStateView S{state.GetData()};
+  //   double rho = S.mass(layout);
+  //   double rhoU = S.momentum(layout, 0);
+  //   double rhoE = S.energy(layout);
+  //
+  // This is a small, value-type-like view with correct indexing.
+  // -----------------------------------------------------------------------------
+  struct PointStateViewRW
+  {
+    real_t* U;                 // packed state data -> [rho, rhoVx, rhoVy, ..., rhoE]
+    
+    MFEM_HOST_DEVICE
+    PointStateViewRW(real_t* U_)
+      : U(U_)
+    { }
+    
+    MFEM_HOST_DEVICE inline bool is_valid() const
+    {
+      return (U != nullptr);
+    }
+    
+    // Mass density
+    MFEM_HOST_DEVICE inline real_t mass(const StateLayout &L) const
+    {
+      const real_t rho = U[ L.eq_mass ];
+      return rho;
+    }
+    
+    // Set Mass density
+    MFEM_HOST_DEVICE inline void set_mass(const StateLayout &L, real_t val)
+    {
+      U[ L.eq_mass ] = val;
+    }
+
+    // Momentum components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline real_t momentum(const StateLayout &L, int d) const
+    {
+      assert(d < L.dim);
+      return U[ L.eq_mom[d] ];
+    }
+    
+    // Set Momentum components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline void set_momentum(const StateLayout &L, int d, real_t val)
+    {
+      assert(d < L.dim);
+      U[ L.eq_mom[d] ] = val;
+    }
+
+    MFEM_HOST_DEVICE inline real_t momentum_x(const StateLayout &L) const
+    {
+      return momentum(L, 0);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t momentum_y(const StateLayout &L) const
+    {
+      return momentum(L, 1);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t momentum_z(const StateLayout &L) const
+    {
+      return momentum(L, 2);
+    }
+    
+    // Velocity components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline real_t velocity(const StateLayout &L, int d) const
+    {
+      return momentum(L, d) / mass(L);
+    }
+
+    MFEM_HOST_DEVICE inline real_t velocity_x(const StateLayout &L) const
+    {
+      return momentum_x(L) / mass(L);
+    }
+
+    MFEM_HOST_DEVICE inline real_t velocity_y(const StateLayout &L) const
+    {
+      return momentum_y(L) / mass(L);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_z(const StateLayout &L) const
+    {
+      return momentum_z(L) / mass(L);
+    }
+    
+    // Total energy
+    MFEM_HOST_DEVICE inline real_t energy(const StateLayout &L) const
+    {
+      return U[ L.eq_energy ];
+    }
+    
+    // Set Total energy
+    MFEM_HOST_DEVICE inline void set_energy(const StateLayout &L, real_t val)
+    {
+      U[ L.eq_energy ] = val;
+    }
+
+    // Scalar components, if present
+    MFEM_HOST_DEVICE inline real_t scalar(const StateLayout &L, int k) const
+    {
+      assert(L.num_scalars > 0);
+      assert((k >= 0 && k < L.num_scalars) && "Invalid scalar index");
+      return U[ L.eq_scalar0 + k ];
+    }
+
+    // Set Scalar components, if present
+    MFEM_HOST_DEVICE inline void set_scalar(const StateLayout &L, int k, real_t val)
+    {
+      assert(L.num_scalars > 0);
+      assert((k >= 0 && k < L.num_scalars) && "Invalid scalar index");
+      U[ L.eq_scalar0 + k ] = val;
+    }
+    
+  };
+
+  // -----------------------------------------------------------------------------
+  // PointPrimitiveView: per-point view
+  //
+  // Usage pattern:
+  //
+  //   Vector state = [rho, Vx, Vy, Vz, p]
+  //   PointStateView S{state.GetData()};
+  //   double rho = S.mass(layout);
+  //   double Vx  = S.velocity(layout, 0);
+  //   double Vy  = S.velocity(layout, 1);
+  //   double p   = S.pressure(layout);
+  //
+  // This is a small, value-type-like view with correct indexing.
+  // -----------------------------------------------------------------------------
+  struct PointPrimitiveView
+  {
+    const real_t* U;           // packed state data -> [rho, rhoVx, rhoVy, ..., rhoE]
+    
+    MFEM_HOST_DEVICE
+    PointPrimitiveView(const real_t* U_)
+      : U(U_)
+    { }
+    
+    MFEM_HOST_DEVICE inline bool is_valid() const
+    {
+      return (U != nullptr);
+    }
+
+    // Mass / density
+    MFEM_HOST_DEVICE inline real_t mass(const StateLayout &L) const
+    {
+      const real_t rho = U[ L.eq_mass ];
+      return rho;
+    }
+    
+    // Array offset to velocity components
+    MFEM_HOST_DEVICE inline int velocity_loc(const StateLayout &L) const
+    {
+      return L.eq_mom0;
+    }
+    // Momentum components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline real_t velocity(const StateLayout &L, int d) const
+    {
+      assert(d < L.dim);
+      return U[ L.eq_mom[d] ];
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_x(const StateLayout &L) const
+    {
+      return velocity(L, 0);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_y(const StateLayout &L) const
+    {
+      return velocity(L, 1);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_z(const StateLayout &L) const
+    {
+      return velocity(L, 2);
+    }
+
+    MFEM_HOST_DEVICE inline real_t pressure(const StateLayout &L) const
+    {
+      return U[ L.eq_energy ];
+    }
+    
+    // Scalar components, if present
+    MFEM_HOST_DEVICE inline real_t scalar(const StateLayout &L, int k) const
+    {
+      assert(L.num_scalars > 0);
+      assert((k >= 0 && k < L.num_scalars) && "Invalid scalar index");
+      return U[ L.eq_scalar0 + k ];
+    }
+  };
+
+  // -----------------------------------------------------------------------------
+  // PointPrimtiveViewRW: *writeable* per-point view
+  //
+  // Usage pattern:
+  //
+  //   Vector state = [rho, rhoVx, rhoVy, rhoVz, rhoE]
+  //   PointStateView S{state.GetData()};
+  //   double r =  S.mass(layout);
+  //   double U = S.velocity(layout, 0);
+  //   double V = S.velocity(layout, 1);
+  //   double p = S.pressure(layout);
+  //   S.set_pressure(layout, p);
+  //
+  // This is a small, value-type-like view with correct indexing.
+  // -----------------------------------------------------------------------------
+  struct PointPrimitiveViewRW
+  {
+    real_t* U;                 // packed state data -> [rho, rhoVx, rhoVy, ..., rhoE]
+    
+    MFEM_HOST_DEVICE
+    PointPrimitiveViewRW(real_t* U_) : U(U_) { }
+
+    MFEM_HOST_DEVICE inline bool is_valid() const
+    {
+      return (U != nullptr);
+    }
+
+    // Mass density
+    MFEM_HOST_DEVICE inline real_t mass(const StateLayout &L) const
+    {
+      const real_t rho = U[ L.eq_mass ];
+      return rho;
+    }
+    
+    // Set Mass density
+    MFEM_HOST_DEVICE inline void set_mass(const StateLayout &L, real_t val)
+    {
+      U[ L.eq_mass ] = val;
+    }
+
+    // Array offset to velocity components
+    MFEM_HOST_DEVICE inline int velocity_loc(const StateLayout &L) const
+    {
+      return L.eq_mom0;
+    }
+
+    // Momentum components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline real_t velocity(const StateLayout &L, int d) const
+    {
+      assert(d < L.dim);
+      return U[ L.eq_mom[d] ];
+    }
+    
+    // Set Momentum components: d = 0(x),1(y),2(z)
+    MFEM_HOST_DEVICE inline void set_velocity(const StateLayout &L, int d, real_t val)
+    {
+      assert(d < L.dim);
+      U[ L.eq_mom[d] ] = val;
+    }
+
+    MFEM_HOST_DEVICE inline real_t velocity_x(const StateLayout &L) const
+    {
+      return velocity(L, 0);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_y(const StateLayout &L) const
+    {
+      return velocity(L, 1);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t velocity_z(const StateLayout &L) const
+    {
+      return velocity(L, 2);
+    }
+    
+    MFEM_HOST_DEVICE inline real_t pressure(const StateLayout &L) const
+    {
+      return U[ L.eq_energy ];
+    }
+    
+    MFEM_HOST_DEVICE inline void set_pressure(const StateLayout &L, real_t val)
+    {
+      U[ L.eq_energy ] = val;
+    }
+
+    // Scalar components, if present
+    MFEM_HOST_DEVICE inline real_t scalar(const StateLayout &L, int k) const
+    {
+      assert(L.num_scalars > 0);
+      assert((k >= 0 && k < L.num_scalars) && "Invalid scalar index");
+      return U[ L.eq_scalar0 + k ];
+    }
+
+    // Set Scalar components, if present
+    MFEM_HOST_DEVICE inline void set_scalar(const StateLayout &L, int k, real_t val)
+    {
+      assert(L.num_scalars > 0);
+      assert((k >= 0 && k < L.num_scalars) && "Invalid scalar index");
+      U[ L.eq_scalar0 + k ] = val;
+    }
+    
+  };
+
+  // -----------------------------------------------------------------------------
+  // DofStateView: per-DOF view (Get conserved quantities for particular DOF)
   //
   // Usage pattern:
   //
   //   const double* U = sol->Read();
   //   StateLayout layout(dim, num_dofs_scalar);
   //   for (int i = 0; i < num_dofs_scalar; ++i) {
-  //       DofStateView<const double> S{U, &layout, i};
-  //       double rho  = S.mass();
-  //       double rhoU = S.momentum(0);
-  //       double E    = S.energy();
+  //       DofStateView<const double> S{U, i};
+  //       double rho  = S.mass(l);
+  //       double rhoU = S.momentum(l, 0);
+  //       double E    = S.energy(l);
   //   }
   //
   // This is a small, value-type-like view with correct indexing.
@@ -257,88 +513,81 @@ namespace Prandtl
   struct DofStateView
   {
     const real_t* U;           // pointer into equation-blocked storage
-    const StateLayout* L;      // layout metadata
     int dof;                   // which DOF (0 .. num_dofs_scalar-1)
     
     MFEM_HOST_DEVICE
-    DofStateView()
-      : U(nullptr), L(nullptr), dof(0)
-    { }
-    
-    MFEM_HOST_DEVICE
     DofStateView(const real_t* U_,
-                 const StateLayout* L_,
                  int dof_)
-      : U(U_), L(L_), dof(dof_)
+      : U(U_), dof(dof_)
     { }
     
     MFEM_HOST_DEVICE inline bool is_valid() const
     {
-      return (U != nullptr) && (L != nullptr);
+      return (U != nullptr);
     }
-    
+
     // Mass / density
-    MFEM_HOST_DEVICE inline real_t mass() const
+    MFEM_HOST_DEVICE inline real_t mass(const StateLayout &L) const
     {
-      const real_t rho = U[ L->index(L->eq_mass, dof) ];
+      const real_t rho = U[ L.index(L.eq_mass, dof) ];
       return rho;
     }
     
     // Momentum components: d = 0(x),1(y),2(z)
-    MFEM_HOST_DEVICE inline real_t momentum(int d) const
+    MFEM_HOST_DEVICE inline real_t momentum(const StateLayout &L, int d) const
     {
-      assert(d < L->dim);
-      return U[ L->index(L->eq_mom[d], dof) ];
+      assert(d < L.dim);
+      return U[ L.index(L.eq_mom[d], dof) ];
     }
     
-    MFEM_HOST_DEVICE inline real_t momentum_x() const
+    MFEM_HOST_DEVICE inline real_t momentum_x(const StateLayout &L) const
     {
-      return momentum(0);
+      return momentum(L, 0);
     }
     
-    MFEM_HOST_DEVICE inline real_t momentum_y() const
+    MFEM_HOST_DEVICE inline real_t momentum_y(const StateLayout &L) const
     {
-      return (L->dim > 1) ? momentum(1) : real_t(0);
+      return momentum(L, 1);
     }
     
-    MFEM_HOST_DEVICE inline real_t momentum_z() const
+    MFEM_HOST_DEVICE inline real_t momentum_z(const StateLayout &L) const
     {
-      return (L->dim > 2) ? momentum(2) : real_t(0);
+      return momentum(L, 2);
     }
     
     // Velocity components: d = 0(x),1(y),2(z)
-    MFEM_HOST_DEVICE inline real_t velocity(int d) const
+    MFEM_HOST_DEVICE inline real_t velocity(const StateLayout &L, int d) const
     {
-      return momentum(d) / mass();
+      return momentum(L, d) / mass(L);
     }
 
-    MFEM_HOST_DEVICE inline real_t velocity_x() const
+    MFEM_HOST_DEVICE inline real_t velocity_x(const StateLayout &L) const
     {
-      return momentum_x() / mass();
+      return velocity(L, 0);
     }
 
-    MFEM_HOST_DEVICE inline real_t velocity_y() const
+    MFEM_HOST_DEVICE inline real_t velocity_y(const StateLayout &L) const
     {
-      return momentum_y() / mass();
+      return velocity(L, 1);
     }
     
-    MFEM_HOST_DEVICE inline real_t velocity_z() const
+    MFEM_HOST_DEVICE inline real_t velocity_z(const StateLayout &L) const
     {
-      return momentum_z() / mass();
+      return velocity(L, 2);
     }
     
     // Total energy
-    MFEM_HOST_DEVICE inline real_t energy() const
+    MFEM_HOST_DEVICE inline real_t energy(const StateLayout &L) const
     {
-      return U[ L->index(L->eq_energy, dof) ];
+      return U[ L.index(L.eq_energy, dof) ];
     }
     
     // Scalar components, if present
-    MFEM_HOST_DEVICE inline real_t scalar(int k) const
+    MFEM_HOST_DEVICE inline real_t scalar(const StateLayout &L, int k) const
     {
-      assert(L->num_scalars > 0);
-      assert(k >= 0 && "Invalid scalar index");
-      return U[ L->index(L->eq_scalar0 + k, dof) ];
+      assert(L.num_scalars > 0);
+      assert(k >= 0 && k < L.num_scalars && "Invalid scalar index");
+      return U[ L.index(L.eq_scalar0 + k, dof) ];
     }
   };
 
@@ -352,91 +601,82 @@ namespace Prandtl
   struct FieldStateView
   {
     real_t* data;                // raw pointer to equation-blocked storage
-    const StateLayout* layout;   // layout metadata
     
     MFEM_HOST_DEVICE
-    FieldStateView()
-      : data(nullptr), layout(nullptr)
-    { }
-    
-    MFEM_HOST_DEVICE
-    FieldStateView(real_t* data_,
-                   const StateLayout* layout_)
-      : data(data_), layout(layout_)
-    { }
-    
+    FieldStateView(real_t* data_) : data(data_) { }
+
     MFEM_HOST_DEVICE inline bool is_valid() const
     {
-      return (data != nullptr) && (layout != nullptr);
+      return (data != nullptr);
     }
     
     // Generic access by (equation, dof)
-    MFEM_HOST_DEVICE inline real_t& u(int equation, int dof) const
+    MFEM_HOST_DEVICE inline real_t& u(const StateLayout &layout, int equation, int dof) const
     {
-      return data[ layout->index(equation, dof) ];
+      return data[ layout.index(equation, dof) ];
     }
     
     // Named accessors for convenience
-    MFEM_HOST_DEVICE inline real_t& mass(int dof) const
+    MFEM_HOST_DEVICE inline real_t& mass(const StateLayout &layout, int dof) const
     {
-      return u(layout->eq_mass, dof);
+      return u(layout, layout.eq_mass, dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t& momentum(int component, int dof) const
+    MFEM_HOST_DEVICE inline real_t& momentum(const StateLayout &layout, int component, int dof) const
     {
-      return u(layout->eq_mom[component], dof);
+      return u(layout, layout.eq_mom[component], dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t& momentum_x(int dof) const
+    MFEM_HOST_DEVICE inline real_t& momentum_x(const StateLayout &layout, int dof) const
     {
-      return u(layout->eq_mom[0], dof);
+      return u(layout, layout.eq_mom[0], dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t& momentum_y(int dof) const
+    MFEM_HOST_DEVICE inline real_t& momentum_y(const StateLayout &layout, int dof) const
     {
-      return u(layout->eq_mom[1], dof);
+      return u(layout, layout.eq_mom[1], dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t& momentum_z(int dof) const
+    MFEM_HOST_DEVICE inline real_t& momentum_z(const StateLayout &layout, int dof) const
     {
-      return u(layout->eq_mom[2], dof);
+      return u(layout, layout.eq_mom[2], dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t velocity(int component, int dof) const
+    MFEM_HOST_DEVICE inline real_t velocity(const StateLayout &layout, int component, int dof) const
     {
-      return momentum(component, dof) / mass(dof);
+      return momentum(layout, component, dof) / mass(layout, dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t velocity_x(int dof) const
+    MFEM_HOST_DEVICE inline real_t velocity_x(const StateLayout &layout, int dof) const
     {
-      return momentum_x(dof) / mass(dof);
+      return velocity(layout, 0, dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t velocity_y(int dof) const
+    MFEM_HOST_DEVICE inline real_t velocity_y(const StateLayout &layout, int dof) const
     {
-      return momentum_y(dof) / mass(dof);
+      return velocity(layout, 1, dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t velocity_z(int dof) const
+    MFEM_HOST_DEVICE inline real_t velocity_z(const StateLayout &layout, int dof) const
     {
-      return momentum_z(dof) / mass(dof);
+      return velocity(layout, 2, dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t& energy(int dof) const
+    MFEM_HOST_DEVICE inline real_t& energy(const StateLayout &layout, int dof) const
     {
-      return u(layout->eq_energy, dof);
+      return u(layout, layout.eq_energy, dof);
     }
     
-    MFEM_HOST_DEVICE inline real_t& scalar(int k, int dof) const
+    MFEM_HOST_DEVICE inline real_t& scalar(const StateLayout &layout, int k, int dof) const
     {
-      assert(layout->num_scalars > 0);
-      assert(k >= 0 && "Invalid scalar index");
-      return u(layout->eq_scalar0 + k, dof);
+      assert(layout.num_scalars > 0);
+      assert(k >= 0 && k < layout.num_scalars && "Invalid scalar index");
+      return u(layout, layout.eq_scalar0 + k, dof);
     }
   };
 
-  inline int offset_mass   (const Prandtl::StateLayout &L) { return L.index(L.eq_mass,   0); }
-  inline int offset_momentum  (const Prandtl::StateLayout &L) { return L.index(L.eq_mom[0], 0); }
+  inline int offset_mass   (const Prandtl::StateLayout &L) { return L.index(L.eq_mass, 0); }
+  inline int offset_momentum  (const Prandtl::StateLayout &L) { return L.index(L.eq_mom0, 0); }
   inline int offset_energy (const Prandtl::StateLayout &L) { return L.index(L.eq_energy, 0); }
   inline int offset_scalars (const Prandtl::StateLayout &L) { return L.index(L.eq_scalar0, 0); };
 

--- a/src/Physics/Physics.hpp
+++ b/src/Physics/Physics.hpp
@@ -1,16 +1,9 @@
 #pragma once
 
-#include "mfem.hpp"
-
-#ifndef MFEM_HOST_DEVICE
-#define MFEM_HOST_DEVICE
-#endif
+#include "Kernels.hpp"
 
 namespace Prandtl
 {
-
-  //using namespace mfem;
-  using real_t = mfem::real_t;
 
   struct PhysicsConstants
   {

--- a/src/Physics/Transport.hpp
+++ b/src/Physics/Transport.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mfem.hpp"
+#include <cmath>
 #include "Physics.hpp"
 #include "GasState.hpp"
 
@@ -13,41 +13,38 @@ namespace Prandtl
   
   struct Transport
   {
-    std::shared_ptr<const PhysicsConstants> phys;
-    
-    MFEM_HOST_DEVICE
-    explicit Transport(std::shared_ptr<const PhysicsConstants> pc)
-      : phys(std::move(pc))
-    { }
     
     template<typename EOSType, typename StateViewType>
     MFEM_HOST_DEVICE
-    inline real_t viscosity(const EOSType &eos, const StateViewType &S) const
+    inline real_t viscosity(const PhysicsConstants &phys, const StateLayout &L,
+                            const EOSType &eos, const StateViewType &S) const
     {
 #ifdef SUTHERLAND
       // mu0 * T0pTs / (T + Ts) * (T / T0) * std::sqrt(T / T0);
-      const real_t temptr = eos.temperature(S);
-      const real_t Trel = temptr / phys->T0;
-      const real_t T0pTs = phys->T0 + phys->Ts;
-      return phys->mu0 * T0pTs * Trel * std::sqrt(Trel) / (temptr + phys->Ts);
+      const real_t temptr = eos.temperature(phys, L, S);
+      const real_t Trel = temptr / phys.T0;
+      const real_t T0pTs = phys.T0 + phys.Ts;
+      return phys.mu0 * T0pTs * Trel * std::sqrt(Trel) / (temptr + phys.Ts);
 #else
-      return phys->mu;
+      return phys.mu;
 #endif
     }
 
     template<typename EOSType, typename StateViewType>
     MFEM_HOST_DEVICE
-    inline real_t bulk_viscosity(const EOSType &eos, const StateViewType &S) const
+    inline real_t bulk_viscosity(const PhysicsConstants &phys, const StateLayout &L,
+                                 const EOSType &eos, const StateViewType &S) const
     {
-      return phys->mu_bulk;
+      return phys.mu_bulk;
     }
 
     // Thermal cond kappa = mu * cp / Pr
     template<typename EOSType, typename StateViewType>
     MFEM_HOST_DEVICE
-    inline real_t thermal_conductivity(const EOSType &eos, const StateViewType &S) const
+    inline real_t thermal_conductivity(const PhysicsConstants &phys, const StateLayout &L,
+                                       const EOSType &eos, const StateViewType &S) const
     {
-      return viscosity(eos, S) * eos.cp(S) * phys->PrInverse;
+      return viscosity(phys, L, eos, S) * eos.cp(phys, L, S) * phys.PrInverse;
     }
   };
   // TODO: Consider refactoring; would be better (explicit) design

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ target_include_directories(gas_tests
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/hypre/src/hypre/include
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/metis-5.1.0/include
     ${PROJECT_SOURCE_DIR}/src/Physics
+    ${PROJECT_SOURCE_DIR}/src/Device
 )
 
 # Propagate SUTHERLAND compile definition to gas_tests if enabled
@@ -62,6 +63,7 @@ target_include_directories(state_tests
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/hypre/src/hypre/include
     PUBLIC ${PROJECT_SOURCE_DIR}/libs/metis-5.1.0/include
     ${PROJECT_SOURCE_DIR}/src/Physics
+    ${PROJECT_SOURCE_DIR}/src/Device
 )
 
 target_link_directories(state_tests

--- a/tests/eos_tests.cpp
+++ b/tests/eos_tests.cpp
@@ -41,7 +41,7 @@ TEST(IdealGas_EOS)
     std::shared_ptr<PhysicsConstants> phys =
       std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
 
-    IdealSingleGasEOS eos{phys};
+    IdealSingleGasEOS eos;
 
     const real_t tol = 1.0e-12;
 
@@ -73,17 +73,17 @@ TEST(IdealGas_EOS)
         // --- Case 1: velocity = u1 -----------------------------------------
         fill_single_dof_state(layout, U, dim, rho, u1, e_int_density);
 
-        DofStateView S1(U.data(), &layout, 0);
+        DofStateView S1(U.data(), 0);
 
-        const real_t p1 = eos.pressure(S1);
+        const real_t p1 = eos.pressure(*phys, layout, S1);
         EXPECT_CLOSE(p1, 1.0, tol);
 
         const real_t T1_expected = p1 / (rho * R_gas);
-        const real_t T1 = eos.temperature(S1);
+        const real_t T1 = eos.temperature(*phys, layout, S1);
         EXPECT_CLOSE(T1, T1_expected, tol);
 
         const real_t a1_expected = std::sqrt(gamma * p1 / rho);
-        const real_t a1 = eos.sound_speed(S1);
+        const real_t a1 = eos.sound_speed(*phys, layout, S1);
         EXPECT_CLOSE(a1, a1_expected, tol);
 
         // --- Case 2: different velocity, same e_int_density ----------------
@@ -91,17 +91,17 @@ TEST(IdealGas_EOS)
 
         fill_single_dof_state(layout, U, dim, rho, u2, e_int_density);
 
-        DofStateView S2(U.data(), &layout, 0);
+        DofStateView S2(U.data(), 0);
 
-        const real_t p2 = eos.pressure(S2);
+        const real_t p2 = eos.pressure(*phys, layout, S2);
         EXPECT_CLOSE(p2, 1.0, tol);  // should be unchanged
 
         const real_t T2_expected = p2 / (rho * R_gas);
-        const real_t T2 = eos.temperature(S2);
+        const real_t T2 = eos.temperature(*phys, layout, S2);
         EXPECT_CLOSE(T2, T2_expected, tol);
 
         const real_t a2_expected = std::sqrt(gamma * p2 / rho);
-        const real_t a2 = eos.sound_speed(S2);
+        const real_t a2 = eos.sound_speed(*phys, layout, S2);
         EXPECT_CLOSE(a2, a2_expected, tol);
     }
 
@@ -128,7 +128,7 @@ TEST(IdealGas_EOS_GradTemperature)
     std::shared_ptr<PhysicsConstants> phys =
       std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
 
-    IdealSingleGasEOS eos{phys};
+    IdealSingleGasEOS eos;
 
     const real_t tol = 1.0e-12;
 
@@ -157,10 +157,10 @@ TEST(IdealGas_EOS_GradTemperature)
         std::vector<real_t> U(num_eq * ndofs);
         fill_single_dof_state(layout, U, dim, rho, u, e_int_density);
 
-        DofStateView S(U.data(), &layout, 0);
+        DofStateView S(U.data(), 0);
 
         // Sanity: ensure EOS returns the intended p, so T is consistent.
-        const real_t p_check = eos.pressure(S);
+        const real_t p_check = eos.pressure(*phys, layout, S);
         EXPECT_CLOSE(p_check, p, tol);
 
         // --- Case A: grad(rho)=0, grad(p)!=0 -------------------------------
@@ -171,7 +171,7 @@ TEST(IdealGas_EOS_GradTemperature)
             // Initialize with sentinels so we detect if EOS overwrites.
             real_t grad_t[3]   = {99.0, 99.0, 99.0};
 
-            eos.grad_temperature(dim, S, grad_rho, grad_p, grad_t);
+            eos.grad_temperature(*phys, layout, S, grad_rho, grad_p, grad_t);
 
             for (int d = 0; d < dim; ++d)
             {
@@ -191,7 +191,7 @@ TEST(IdealGas_EOS_GradTemperature)
 
             real_t grad_t[3]   = {99.0, 99.0, 99.0};
 
-            eos.grad_temperature(dim, S, grad_rho, grad_p, grad_t);
+            eos.grad_temperature(*phys, layout, S, grad_rho, grad_p, grad_t);
 
             for (int d = 0; d < dim; ++d)
             {
@@ -222,7 +222,7 @@ TEST(IdealGas_EOS_HelperFunctions)
     std::shared_ptr<PhysicsConstants> phys =
       std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
 
-    IdealSingleGasEOS eos{phys};
+    IdealSingleGasEOS eos;
 
     const real_t tol = 1.0e-12;
 
@@ -240,7 +240,7 @@ TEST(IdealGas_EOS_HelperFunctions)
         std::vector<real_t> U(num_eq * ndofs);
         fill_single_dof_state(layout, U, dim, rho, u, e_int_density);
 
-        DofStateView S(U.data(), &layout, 0);
+        DofStateView S(U.data(), 0);
 
         // Compute expected values analytically.
         real_t u2 = 0.0;
@@ -259,18 +259,172 @@ TEST(IdealGas_EOS_HelperFunctions)
 
         // ---- EOS helper checks ------------------------------------------------
 
-        EXPECT_CLOSE(eos.momentum_sq(S), mom_sq, tol);
-        EXPECT_CLOSE(eos.kinetic_energy_density(S), ke_expected, tol);
-        EXPECT_CLOSE(eos.internal_energy_density(S), ie_expected, tol);
-        EXPECT_CLOSE(eos.specific_internal_energy(S), sie_expected, tol);
-        EXPECT_CLOSE(eos.cp(S), cp_expected, tol);
+        EXPECT_CLOSE(eos.momentum_sq(*phys, layout, S), mom_sq, tol);
+        EXPECT_CLOSE(eos.kinetic_energy_density(*phys, layout, S), ke_expected, tol);
+        EXPECT_CLOSE(eos.internal_energy_density(*phys, layout, S), ie_expected, tol);
+        EXPECT_CLOSE(eos.specific_internal_energy(*phys, layout, S), sie_expected, tol);
+        EXPECT_CLOSE(eos.cp(*phys, layout, S), cp_expected, tol);
 
         // EOS velocity helper
         real_t u_out[3] = { 99.0, 99.0, 99.0 };
-        eos.velocity(S, u_out);
+        eos.velocity(*phys, layout, S, u_out);
         for (int d = 0; d < dim; ++d)
         {
             EXPECT_CLOSE(u_out[d], u[d], tol);
+        }
+    }
+
+    return 0;
+}
+
+// -----------------------------------------------------------------------------
+// EOS test: entropy scalar for ideal gas
+//
+// entropy(S) = log(p) - gamma*log(rho)
+//
+// We choose rho, u, and e_int_density to realize a prescribed p via
+//   p = (gamma-1) * e_int_density
+// and then verify entropy is independent of velocity.
+// -----------------------------------------------------------------------------
+TEST(IdealGas_EOS_Entropy)
+{
+    const real_t gamma = 1.4;
+    const real_t Pr    = 0.72;
+    const real_t R_gas = 287.0;
+    const real_t mu    = 1.8e-5;
+
+    std::shared_ptr<PhysicsConstants> phys =
+      std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
+
+    IdealSingleGasEOS eos;
+
+    const real_t tol = 1.0e-12;
+
+    // Prescribed thermodynamic values
+    const real_t rho = 2.5;
+    const real_t p   = 3.75;
+
+    // Choose internal energy density so EOS returns exactly p independent of u:
+    //   p = (gamma-1) * e_int_density
+    const real_t e_int_density = p / (gamma - 1.0);
+
+    const real_t u1[3] = {10.0, -3.0, 5.0};
+    const real_t u2[3] = {-4.0, 7.0, 1.0};
+
+    for (int dim = 1; dim <= 3; ++dim)
+    {
+        const int ndofs = 1;
+        StateLayout layout(dim, ndofs);  // no scalars
+        const int num_eq = layout.eq_energy + 1;
+
+        std::vector<real_t> U(num_eq * ndofs);
+
+        // Case 1: u1
+        fill_single_dof_state(layout, U, dim, rho, u1, e_int_density);
+        DofStateView S1(U.data(), 0);
+
+        const real_t p1 = eos.pressure(*phys, layout, S1);
+        EXPECT_CLOSE(p1, p, tol);
+
+        const real_t s_expected = std::log(p) - gamma * std::log(rho);
+        const real_t s1 = eos.entropy(*phys, layout, S1);
+        EXPECT_CLOSE(s1, s_expected, tol);
+
+        // Case 2: u2 (same rho, same e_int_density => same p)
+        fill_single_dof_state(layout, U, dim, rho, u2, e_int_density);
+        DofStateView S2(U.data(), 0);
+
+        const real_t p2 = eos.pressure(*phys, layout, S2);
+        EXPECT_CLOSE(p2, p, tol);
+
+        const real_t s2 = eos.entropy(*phys, layout, S2);
+        EXPECT_CLOSE(s2, s_expected, tol);  // must be velocity-independent
+    }
+
+    return 0;
+}
+
+// -----------------------------------------------------------------------------
+// EOS test: entropy_state (entropy variables) for ideal gas
+//
+// Validates the mapping used in your EOS::entropy_state implementation:
+//
+//   s      = log(p) - gamma*log(rho)
+//   beta   = rho/p
+//   v2o2   = (0.5*|u|^2)
+//   w_rho  = (gamma - s)/(gamma-1) - beta*v2o2
+//   w_mom  = beta * u
+//   w_E    = -beta
+//
+// And (for now) verifies scalars are set to 0.0 per your TODO-stub.
+// -----------------------------------------------------------------------------
+TEST(IdealGas_EOS_EntropyState)
+{
+    const real_t gamma = 1.4;
+    const real_t Pr    = 0.72;
+    const real_t R_gas = 287.0;
+    const real_t mu    = 1.8e-5;
+
+    std::shared_ptr<PhysicsConstants> phys =
+      std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
+
+    IdealSingleGasEOS eos;
+
+    const real_t tol = 1.0e-12;
+
+    const real_t rho = 1.7;
+    const real_t p   = 2.25;
+    const real_t e_int_density = p / (gamma - 1.0);
+
+    const real_t u[3] = {3.0, -4.0, 2.0};
+
+    for (int dim = 1; dim <= 3; ++dim)
+    {
+        const int ndofs = 1;
+        const int nscalars = 2;                 // exercise scalar plumbing
+        StateLayout layout(dim, ndofs, nscalars);
+        const int num_eq = dim + 2 + nscalars;
+
+        // Input conservative state (single DOF, equation-blocked)
+        std::vector<real_t> U(num_eq * ndofs, 0.0);
+        fill_single_dof_state(layout, U, dim, rho, u, e_int_density);
+
+        // Add nonzero scalars to ensure entropy_state currently ignores them
+        // and overwrites outputs to 0.0 as intended.
+        for (int k = 0; k < nscalars; ++k)
+        {
+            U[layout.index(layout.eq_scalar0 + k, 0)] = 10.0 + k;
+        }
+
+        DofStateView S(U.data(), 0);
+
+        // Output buffer for entropy variables (single DOF)
+        std::vector<real_t> W(num_eq * ndofs, 777.0); // sentinel fill
+        PointStateViewRW E(W.data());
+
+        eos.entropy_state(*phys, layout, S, E);
+
+        // Expected values
+        const real_t beta = rho / p;
+        real_t u2 = 0.0;
+        for (int d = 0; d < dim; ++d) { u2 += u[d]*u[d]; }
+        const real_t v2o2 = 0.5 * u2;
+
+        const real_t s = std::log(p) - gamma * std::log(rho);
+        const real_t w_rho = (gamma - s) / (gamma - 1.0) - beta * v2o2;
+
+        EXPECT_CLOSE(E.mass(layout), w_rho, tol);
+
+        for (int d = 0; d < dim; ++d)
+        {
+          EXPECT_CLOSE(E.momentum(layout, d), beta * u[d], tol);
+        }
+
+        EXPECT_CLOSE(E.energy(layout), -beta, tol);
+
+        for (int k = 0; k < nscalars; ++k)
+        {
+          EXPECT_CLOSE(E.scalar(layout, k), 0.0, tol);
         }
     }
 

--- a/tests/gas_model_tests.cpp
+++ b/tests/gas_model_tests.cpp
@@ -37,14 +37,14 @@ TEST(GasModel_IdealGas_EOS)
     std::shared_ptr<PhysicsConstants> phys =
       std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
 
-    IdealGasModel gas(phys);
-
     const real_t tol = 1.0e-12;
 
     for (int dim = 1; dim <= 3; ++dim)
     {
         const int ndofs = 1;
         StateLayout layout(dim, ndofs);  // no scalars
+        IdealGasModel gas(*phys, layout);
+
         const int num_eq = layout.eq_energy + 1; // dim+2
 
         std::vector<real_t> U(num_eq * ndofs);
@@ -68,7 +68,7 @@ TEST(GasModel_IdealGas_EOS)
 
         fill_single_dof_state(layout, U, dim, rho, u, e_int_density);
 
-        DofStateView S(U.data(), &layout, 0);
+        DofStateView S(U.data(), 0);
 
         // Pressure
         const real_t p = gas.pressure(S);
@@ -124,9 +124,8 @@ TEST(GasModel_IdealGas_Transport)
     std::shared_ptr<PhysicsConstants> phys =
       std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
 
-    IdealGasModel      gas(phys);
-    IdealSingleGasEOS  eos(phys);
-    Transport          transport(phys);
+    IdealSingleGasEOS  eos;
+    Transport          transport;
 
     const real_t tol = 1.0e-12;
 
@@ -135,6 +134,7 @@ TEST(GasModel_IdealGas_Transport)
     const int dim   = 3;
     const int ndofs = 1;
     StateLayout layout(dim, ndofs);
+    IdealGasModel gas(*phys, layout);
 
     const int num_eq = layout.eq_energy + 1;
     std::vector<real_t> U(num_eq * ndofs);
@@ -147,14 +147,14 @@ TEST(GasModel_IdealGas_Transport)
 
     fill_single_dof_state(layout, U, dim, rho, u, e_int_density);
 
-    DofStateView S(U.data(), &layout, 0);
+    DofStateView S(U.data(), 0);
 
     // Use the EOS + Transport directly to compute the expected results
-    const real_t T  = eos.temperature(S);
-    const real_t cp = eos.cp(S);
+    const real_t T  = eos.temperature(*phys, layout, S);
+    const real_t cp = eos.cp(*phys, layout, S);
 
-    const real_t mu_expected = transport.viscosity(eos, S);
-    const real_t k_expected  = transport.thermal_conductivity(eos, S);
+    const real_t mu_expected = transport.viscosity(*phys, layout, eos, S);
+    const real_t k_expected  = transport.thermal_conductivity(*phys, layout, eos, S);
 
     const real_t mu_gas = gas.viscosity(S);
     const real_t k_gas  = gas.thermal_conductivity(S);
@@ -162,5 +162,128 @@ TEST(GasModel_IdealGas_Transport)
     EXPECT_EQ(mu_gas, mu_expected);
     EXPECT_EQ(k_gas,  k_expected);
 
+    return 0;
+}
+
+// -----------------------------------------------------------------------------
+// GasModel entropy-gradient -> primitive-gradient transform regression test.
+//
+// Goal: ensure the refactored IdealGasModel::grad_entropy_to_grad_prim(...) is
+// algebraically consistent with the legacy EntropyGrad2PrimGrad(...) routine.
+//
+// The legacy routine operated point-wise (per DOF) on:
+//   - conservative state Q = [rho, rho*u_0.., rhoE]
+//   - an input "entropy gradient" vector dE (same slot layout as entropy vars)
+//
+// and produced an output vector (same slot layout as Q) via:
+//   out_mom[i]  = p/rho * ( dE_mom[i] + u_i * dE_last )
+//   out_mass    = rho*dE_mass - dE_last*(KE - p/(gamma-1)) + (rho/p)*sum(mom_i*out_mom[i])
+//   out_last    = p/rho * ( out_mass + p*dE_last )
+//
+// Here, dE_last corresponds to the last slot of the entropy-variable vector
+// (w_E = -beta for ideal gas), and KE is the kinetic energy density.
+// -----------------------------------------------------------------------------
+static void
+legacy_entropy_grad_to_prim_grad(const real_t* Q,
+                                 const real_t* dE,
+                                 real_t* out,
+                                 int dim,
+                                 real_t gamma)
+{
+    const real_t rho = Q[0];
+
+    // Velocity
+    real_t u[3] = {0, 0, 0};
+    real_t u2 = 0;
+    for (int i = 0; i < dim; ++i)
+    {
+        u[i] = Q[1 + i] / rho;
+        u2 += u[i] * u[i];
+    }
+
+    const real_t KE = real_t(0.5) * rho * u2;          // kinetic energy density
+    const real_t rhoE = Q[dim + 1];
+    const real_t p = (gamma - real_t(1)) * (rhoE - KE);
+
+    const real_t gammaM1Inv = real_t(1) / (gamma - real_t(1));
+    const real_t ie = p * gammaM1Inv;                  // internal energy density
+
+    const real_t dE_last = dE[dim + 1];
+
+    // out_mom[i]
+    real_t mom_dot = 0;
+    for (int i = 0; i < dim; ++i)
+    {
+        const real_t out_i = (p / rho) * (dE[1 + i] + u[i] * dE_last);
+        out[1 + i] = out_i;
+        mom_dot += Q[1 + i] * out_i; // (rho*u_i) * out_i
+    }
+
+    // out_mass
+    const real_t out_mass = rho * dE[0] - dE_last * (KE - ie) + (rho / p) * mom_dot;
+    out[0] = out_mass;
+
+    // out_last
+    out[dim + 1] = (p / rho) * (out_mass + p * dE_last);
+}
+
+TEST(GasModel_IdealGas_GradEntropyToGradPrim_MatchesLegacy)
+{
+    const real_t gamma = 1.4;
+    const real_t Pr    = 0.72;
+    const real_t R_gas = 287.0;
+    const real_t mu    = 1.8e-5;
+
+    std::shared_ptr<PhysicsConstants> phys =
+      std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
+
+    const real_t tol = 5.0e-11;
+
+    for (int dim = 1; dim <= 3; ++dim)
+    {
+        const int ndofs = 1;
+        StateLayout layout(dim, ndofs); // no scalars
+        IdealGasModel gas(*phys, layout);
+        const int num_eq = layout.nequations();
+
+        std::vector<real_t> Q(num_eq);
+
+        // Choose a state with positive pressure.
+        const real_t rho = 1.7;
+        const real_t uvec[3] = {35.0, -7.0, 2.5};
+        const real_t e_int_density = 2.3; // arbitrary positive
+
+        fill_single_dof_state(layout, Q, dim, rho, uvec, e_int_density);
+
+        // Synthetic entropy-variable gradient input (dE); does not need to be physical.
+        std::vector<real_t> dE(num_eq);
+        dE[0] = 0.11;
+        for (int i = 0; i < dim; ++i)
+            dE[1 + i] = 0.2 + 0.05 * (i + 1);
+        dE[dim + 1] = -0.33;
+
+        // Compute expected (legacy) output.
+        std::vector<real_t> out_expected(num_eq, 0.0);
+        legacy_entropy_grad_to_prim_grad(Q.data(), dE.data(), out_expected.data(), dim, gamma);
+
+        // Compute refactored output.
+        std::vector<real_t> out(num_eq, 0.0);
+        PointStateView   S{Q.data()};
+        PointStateView   dE_view{dE.data()};
+        PointStateViewRW out_view{out.data()};
+
+        gas.grad_entropy_to_grad_prim(S, dE_view, out_view);
+
+        // Compare slots.
+        for (int eq = 0; eq < num_eq; ++eq){
+            EXPECT_CLOSE(out[eq], out_expected[eq], tol);
+            if (std::abs(out[eq] - out_expected[eq]) > tol) {
+              std::cerr << "eq=" << eq
+                        << " out=" << out[eq]
+                        << " ref=" << out_expected[eq]
+                        << " diff=" << (out[eq] - out_expected[eq]) << "\n";
+            }
+        }
+    }
     return 0;
 }

--- a/tests/gas_state_adapter.hpp
+++ b/tests/gas_state_adapter.hpp
@@ -13,7 +13,7 @@ public:
     GasStateSemanticsAdapter(int dim, int num_dofs_scalar)
         : layout_(dim, num_dofs_scalar),
           data_((dim + 2 + layout_.num_scalars) * num_dofs_scalar),
-          view_(data_.data(), &layout_)
+          view_(data_.data())
     { }
 
     // --- StateSemantics "contract" API ---
@@ -24,33 +24,33 @@ public:
     // Getters
     real_t mass(int i) const
     {
-        return view_.mass(i);
+      return view_.mass(layout_, i);
     }
 
     real_t momentum(int d, int i) const
     {
-        return view_.momentum(d, i);
+      return view_.momentum(layout_, d, i);
     }
 
     real_t energy(int i) const
     {
-        return view_.energy(i);
+      return view_.energy(layout_, i);
     }
 
     // Setters
     void set_mass(int i, real_t rho)
     {
-        view_.mass(i) = rho;
+      view_.mass(layout_, i) = rho;
     }
 
     void set_momentum(int d, int i, real_t rho_u_d)
     {
-        view_.momentum(d, i) = rho_u_d;
+      view_.momentum(layout_, d, i) = rho_u_d;
     }
 
     void set_energy(int i, real_t rhoE)
     {
-        view_.energy(i) = rhoE;
+      view_.energy(layout_, i) = rhoE;
     }
 
 private:

--- a/tests/state_tests.cpp
+++ b/tests/state_tests.cpp
@@ -62,6 +62,7 @@ TEST(StateLayout_Indexing_NoScalars_2D)
     EXPECT_CLOSE(layout.dim,             dim,     0.0);
     EXPECT_CLOSE(layout.num_dofs_scalar, ndofs,   0.0);
     EXPECT_CLOSE(layout.eq_mass,         0,       0.0);
+    EXPECT_CLOSE(layout.eq_mom0,         1,       0.0);
     EXPECT_CLOSE(layout.eq_mom[0],       1,       0.0);
     EXPECT_CLOSE(layout.eq_mom[1],       2,       0.0);
     EXPECT_CLOSE(layout.eq_mom[2],      -1,       0.0); // unused in 2D
@@ -94,6 +95,7 @@ TEST(StateLayout_Indexing_WithScalars_3D)
     EXPECT_CLOSE(layout.dim,             dim,                  0.0);
     EXPECT_CLOSE(layout.num_dofs_scalar, ndofs,                0.0);
     EXPECT_CLOSE(layout.eq_mass,         0,                    0.0);
+    EXPECT_CLOSE(layout.eq_mom0,         1,                    0.0);
     EXPECT_CLOSE(layout.eq_mom[0],       1,                    0.0);
     EXPECT_CLOSE(layout.eq_mom[1],       2,                    0.0);
     EXPECT_CLOSE(layout.eq_mom[2],       3,                    0.0);
@@ -149,24 +151,24 @@ TEST(DofStateView_ReadsExpectedComponents)
 
     for (int i = 0; i < ndofs; ++i)
     {
-        Prandtl::DofStateView S{U.data(), &layout, i};
+        Prandtl::DofStateView S{U.data(), i};
 
         // Mass
-        EXPECT_EQ(S.mass(), 10.0 * layout.eq_mass + i + 1);
+        EXPECT_EQ(S.mass(layout), 10.0 * layout.eq_mass + i + 1);
 
         // Momentum components
         for (int d = 0; d < dim; ++d)
         {
             const int eq_m = layout.eq_mom[d];
-            EXPECT_EQ(S.momentum(d), 10.0 * eq_m + i + 1);
+            EXPECT_EQ(S.momentum(layout, d), 10.0 * eq_m + i + 1);
             if (d == 0){
-              EXPECT_EQ(S.momentum_x(), S.momentum(d));
+              EXPECT_EQ(S.momentum_x(layout), S.momentum(layout, d));
             }
             if (d == 1){
-              EXPECT_EQ(S.momentum_y(), S.momentum(d));
+              EXPECT_EQ(S.momentum_y(layout), S.momentum(layout, d));
             }
             if (d == 2){
-              EXPECT_EQ(S.momentum_z(), S.momentum(d));
+              EXPECT_EQ(S.momentum_z(layout), S.momentum(layout, d));
             }
         }
 
@@ -174,25 +176,25 @@ TEST(DofStateView_ReadsExpectedComponents)
         for (int d = 0; d < dim; ++d)
         {
           const int eq_m = layout.eq_mom[d];
-          EXPECT_CLOSE(S.velocity(d),(10.0*eq_m+i+1)/(i+1), 1e-16);
+          EXPECT_CLOSE(S.velocity(layout, d),(10.0*eq_m+i+1)/(i+1), 1e-16);
           if (d == 0){
-            EXPECT_EQ(S.velocity_x(), S.velocity(d));
+            EXPECT_EQ(S.velocity_x(layout), S.velocity(layout, d));
           }
           if (d == 1){
-            EXPECT_EQ(S.velocity_y(), S.velocity(d));
+            EXPECT_EQ(S.velocity_y(layout), S.velocity(layout, d));
           }
           if (d == 2){
-            EXPECT_EQ(S.velocity_z(), S.velocity(d));
+            EXPECT_EQ(S.velocity_z(layout), S.velocity(layout, d));
           }
         }
         
         // Energy
-        EXPECT_EQ(S.energy(), 10.0 * layout.eq_energy + i + 1);
+        EXPECT_EQ(S.energy(layout), 10.0 * layout.eq_energy + i + 1);
         
         // Scalars
         for(int s = 0; s < nscalars; s++){
           const int eq_s = layout.eq_scalar0;
-          EXPECT_EQ(S.scalar(s),10.0*(eq_s+s) + i + 1);
+          EXPECT_EQ(S.scalar(layout, s),10.0*(eq_s+s) + i + 1);
         }
     }    
     return 0;
@@ -216,44 +218,44 @@ TEST(PointStateView_ReadsExpectedComponents)
       U[eq] = 10.0 * eq + 2;
     }
   
-  Prandtl::PointStateView S{U.data(), &layout};
+  Prandtl::PointStateView S{U.data()};
   
   // Mass
-  EXPECT_EQ(S.mass(), 10.0 * layout.eq_mass + 2);
+  EXPECT_EQ(S.mass(layout), 10.0 * layout.eq_mass + 2);
   
   // Momentum components
   for (int d = 0; d < dim; ++d)
     {
       const int eq_m = layout.eq_mom[d];
-      EXPECT_EQ(S.momentum(d), 10.0 * eq_m + 2);
+      EXPECT_EQ(S.momentum(layout, d), 10.0 * eq_m + 2);
       if (d == 0){
-        EXPECT_EQ(S.momentum_x(), S.momentum(d));
+        EXPECT_EQ(S.momentum_x(layout), S.momentum(layout, d));
       }
       if (d == 1){
-        EXPECT_EQ(S.momentum_y(), S.momentum(d));
+        EXPECT_EQ(S.momentum_y(layout), S.momentum(layout, d));
       }
       if (d == 2){
-        EXPECT_EQ(S.momentum_z(), S.momentum(d));
+        EXPECT_EQ(S.momentum_z(layout), S.momentum(layout, d));
       }
-      EXPECT_CLOSE(S.velocity(d),(10.0*eq_m+2)/2, 1e-16);
+      EXPECT_CLOSE(S.velocity(layout, d),(10.0*eq_m+2)/2, 1e-16);
       if (d == 0){
-        EXPECT_EQ(S.velocity_x(), S.velocity(d));
+        EXPECT_EQ(S.velocity_x(layout), S.velocity(layout, d));
       }
       if (d == 1){
-        EXPECT_EQ(S.velocity_y(), S.velocity(d));
+        EXPECT_EQ(S.velocity_y(layout), S.velocity(layout, d));
       }
       if (d == 2){
-        EXPECT_EQ(S.velocity_z(), S.velocity(d));
+        EXPECT_EQ(S.velocity_z(layout), S.velocity(layout, d));
       }
     }
   
   // Energy
-  EXPECT_EQ(S.energy(), 10.0 * layout.eq_energy + 2);
+  EXPECT_EQ(S.energy(layout), 10.0 * layout.eq_energy + 2);
   
   // Scalars
   for(int s = 0; s < nscalars; s++){
     const int eq_s = layout.eq_scalar0;
-    EXPECT_EQ(S.scalar(s),10.0*(eq_s+s) + 2);
+    EXPECT_EQ(S.scalar(layout, s),10.0*(eq_s+s) + 2);
   }
   return 0;
 }
@@ -268,35 +270,101 @@ TEST(FieldStateView_ReadWriteRoundTrip)
     const int num_eq = dim + 2 + num_scalars;
 
     std::vector<real_t> U(num_eq * ndofs, 0.0);
-    Prandtl::FieldStateView S{U.data(), &layout};
+    Prandtl::FieldStateView S{U.data()};
 
     // Write using named accessors
     for (int i = 0; i < ndofs; ++i)
     {
-        S.mass(i)       = 1.0 + i;
-        S.momentum_x(i) = 2.0 + i;
-        S.momentum_y(i) = 3.0 + i;
-        S.momentum_z(i) = 4.0 + i;
-        S.energy(i)     = 5.0 + i;
-        S.scalar(0, i)  = 6.0 + i;
-        S.scalar(1, i)  = 7.0 + i;
+      S.mass(layout, i)       = 1.0 + i;
+      S.momentum_x(layout, i) = 2.0 + i;
+      S.momentum_y(layout, i) = 3.0 + i;
+      S.momentum_z(layout, i) = 4.0 + i;
+      S.energy(layout, i)     = 5.0 + i;
+      S.scalar(layout, 0, i)  = 6.0 + i;
+      S.scalar(layout, 1, i)  = 7.0 + i;
     }
 
     // Read back
     for (int i = 0; i < ndofs; ++i)
     {
-      EXPECT_EQ(S.mass(i),       1.0 + i);
-      EXPECT_EQ(S.momentum_x(i), 2.0 + i);
-      EXPECT_EQ(S.momentum_y(i), 3.0 + i);
-      EXPECT_EQ(S.momentum_z(i), 4.0 + i);
-      EXPECT_EQ(S.energy(i),     5.0 + i);
-      EXPECT_EQ(S.scalar(0, i),  6.0 + i);
-      EXPECT_EQ(S.scalar(1, i),  7.0 + i);
-      EXPECT_CLOSE(S.velocity_x(i), (2.0 + i)/(1.0 + i), 1e-16);
-      EXPECT_CLOSE(S.velocity_y(i), (3.0 + i)/(1.0 + i), 1e-16);
-      EXPECT_CLOSE(S.velocity_z(i), (4.0 + i)/(1.0 + i), 1e-16);
+      EXPECT_EQ(S.mass(layout,i),       1.0 + i);
+      EXPECT_EQ(S.momentum_x(layout, i), 2.0 + i);
+      EXPECT_EQ(S.momentum_y(layout, i), 3.0 + i);
+      EXPECT_EQ(S.momentum_z(layout, i), 4.0 + i);
+      EXPECT_EQ(S.energy(layout, i),     5.0 + i);
+      EXPECT_EQ(S.scalar(layout, 0, i),  6.0 + i);
+      EXPECT_EQ(S.scalar(layout, 1, i),  7.0 + i);
+      EXPECT_CLOSE(S.velocity_x(layout, i), (2.0 + i)/(1.0 + i), 1e-16);
+      EXPECT_CLOSE(S.velocity_y(layout, i), (3.0 + i)/(1.0 + i), 1e-16);
+      EXPECT_CLOSE(S.velocity_z(layout, i), (4.0 + i)/(1.0 + i), 1e-16);
     }
 
     return 0;
 }
 
+
+TEST(PointStateViewRW_WritesExpectedComponents)
+{
+    const int dim   = 3;
+    const int ndofs = 1;
+    const int nscalars = 2;
+
+    Prandtl::StateLayout layout(dim, ndofs, nscalars);
+    const int num_eq = dim + 2 + nscalars;
+
+    std::vector<real_t> U(num_eq, -1.0);
+
+    Prandtl::PointStateViewRW E{U.data()};
+
+    // Write via setters
+    E.set_mass(layout, 2.0);
+    E.set_momentum(layout, 0, 3.0);
+    E.set_momentum(layout, 1, -4.0);
+    E.set_momentum(layout, 2, 5.0);
+    E.set_energy(layout, 9.0);
+    E.set_scalar(layout, 0, 11.0);
+    E.set_scalar(layout, 1, 12.0);
+
+    // Read back via RW view
+    EXPECT_EQ(E.mass(layout), 2.0);
+    EXPECT_EQ(E.momentum(layout, 0), 3.0);
+    EXPECT_EQ(E.momentum(layout, 1), -4.0);
+    EXPECT_EQ(E.momentum(layout, 2), 5.0);
+    EXPECT_EQ(E.energy(layout), 9.0);
+    EXPECT_EQ(E.scalar(layout,0), 11.0);
+    EXPECT_EQ(E.scalar(layout,1), 12.0);
+
+    // Cross-check via const view over same buffer
+    Prandtl::PointStateView S{U.data()};
+
+    EXPECT_EQ(S.mass(layout), 2.0);
+    EXPECT_EQ(S.momentum(layout, 0), 3.0);
+    EXPECT_EQ(S.momentum(layout, 1), -4.0);
+    EXPECT_EQ(S.momentum(layout, 2), 5.0);
+    EXPECT_EQ(S.energy(layout), 9.0);
+    EXPECT_EQ(S.scalar(layout, 0), 11.0);
+    EXPECT_EQ(S.scalar(layout, 1), 12.0);
+
+    return 0;
+}
+
+
+TEST(PointStateViewRW_WritesToMFEMVector)
+{
+  Prandtl::StateLayout layout(/*dim=*/2, /*ndofs=*/1, /*num_scalars=*/0);
+  mfem::Vector v(layout.nequations());
+  v = 0.0;
+
+  Prandtl::PointStateViewRW E(v.GetData());
+  E.set_mass(layout, 2.0);
+  E.set_momentum(layout, 0, 3.0);
+  E.set_momentum(layout, 1, -4.0);
+  E.set_energy(layout, 9.0);
+
+  EXPECT_EQ(v[layout.eq_mass], 2.0);
+  EXPECT_EQ(v[layout.eq_mom[0]], 3.0);
+  EXPECT_EQ(v[layout.eq_mom[1]], -4.0);
+  EXPECT_EQ(v[layout.eq_energy], 9.0);
+
+  return 0;
+}

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "mfem.hpp"
 #include "GasState.hpp"
 
 using Prandtl::real_t;

--- a/tests/transport_tests.cpp
+++ b/tests/transport_tests.cpp
@@ -1,4 +1,5 @@
 #include "unit_test.hpp"
+#include "mfem.hpp"
 #include "Physics.hpp"
 #include "Transport.hpp"
 #include "EOS.hpp"
@@ -23,8 +24,8 @@ TEST(Transport_mu_kappa)
     std::shared_ptr<PhysicsConstants> phys =
       std::make_shared<PhysicsConstants>(gamma, Pr, R_gas, mu);
 
-    IdealSingleGasEOS eos(phys);
-    Transport transport(phys);
+    IdealSingleGasEOS eos;
+    Transport transport;
     StateLayout layout{3,1};
     real_t rho = 1.0;
     real_t rhoVx = 0.0;
@@ -41,8 +42,8 @@ TEST(Transport_mu_kappa)
 
     real_t state_data_T1[5] = {rho, rhoVx, rhoVy, rhoVz, T1*R_gas/(gamma-1.0)};
     real_t state_data_T2[5] = {rho, rhoVx, rhoVy, rhoVz, T2*R_gas/(gamma-1.0)};
-    PointStateView S1{state_data_T1, &layout};
-    PointStateView S2{state_data_T2, &layout};
+    PointStateView S1{state_data_T1};
+    PointStateView S2{state_data_T2};
 
 #ifdef SUTHERLAND
     // -------------------------------------------------------------------------
@@ -58,8 +59,8 @@ TEST(Transport_mu_kappa)
     const real_t mu1_expected = sutherland_mu(T1);
     const real_t mu2_expected = sutherland_mu(T2);
 
-    const real_t mu1 = transport.viscosity(eos, S1);
-    const real_t mu2 = transport.viscosity(eos, S2);
+    const real_t mu1 = transport.viscosity(*phys, layout, eos, S1);
+    const real_t mu2 = transport.viscosity(*phys, layout, eos, S2);
 
     // Check viscosity matches Sutherland formula
     EXPECT_CLOSE(mu1, mu1_expected, tol);
@@ -72,8 +73,8 @@ TEST(Transport_mu_kappa)
     const real_t k1_expected = mu1_expected * cp * phys->PrInverse;
     const real_t k2_expected = mu2_expected * cp * phys->PrInverse;
 
-    const real_t k1 = transport.thermal_conductivity(eos, S1);
-    const real_t k2 = transport.thermal_conductivity(eos, S2);
+    const real_t k1 = transport.thermal_conductivity(*phys, layout, eos, S1);
+    const real_t k2 = transport.thermal_conductivity(*phys, layout, eos, S2);
 
     EXPECT_CLOSE(k1, k1_expected, tol);
     EXPECT_CLOSE(k2, k2_expected, tol);
@@ -82,8 +83,8 @@ TEST(Transport_mu_kappa)
     // -------------------------------------------------------------------------
     // Constant-transport behavior
     // -------------------------------------------------------------------------
-    const real_t mu1 = transport.viscosity(eos, S1);
-    const real_t mu2 = transport.viscosity(eos, S2);
+    const real_t mu1 = transport.viscosity(*phys, layout, eos, S1);
+    const real_t mu2 = transport.viscosity(*phys, layout, eos, S2);
 
     // Viscosity should be equal to phys->mu for any T
     EXPECT_CLOSE(mu1, phys->mu, tol);
@@ -93,8 +94,8 @@ TEST(Transport_mu_kappa)
     // Thermal conductivity: constant k = mu * cp / Pr
     const real_t k_expected = phys->mu * cp * phys->PrInverse;
 
-    const real_t k1 = transport.thermal_conductivity(eos, S1);
-    const real_t k2 = transport.thermal_conductivity(eos, S2);
+    const real_t k1 = transport.thermal_conductivity(*phys, layout, eos, S1);
+    const real_t k2 = transport.thermal_conductivity(*phys, layout, eos, S2);
 
     EXPECT_CLOSE(k1, k_expected, tol);
     EXPECT_CLOSE(k2, k_expected, tol);


### PR DESCRIPTION
## ⚠️ This PR is part of a cascade of PRs which should be reviewed in order:

1. #37  Fixes a bug in Prandtl
2. #38 (this one) Updates to POD version of GasModel
3. #39 Updates Prandtl to use the new GasModel

--------


## Pull request overview

This PR refactors the state management and gas physics API to support device execution and improve modularity. The key changes involve decoupling state layout information from state views and refactoring EOS/Transport/GasModel interfaces to accept PhysicsConstants and StateLayout as explicit parameters rather than storing them internally.

**Changes:**
- Refactored state view classes (PointStateView, DofStateView, FieldStateView) to accept StateLayout as function parameters instead of storing pointers
- Added new view types (PointStateViewRW, PointPrimitiveView, PointPrimitiveViewRW) for different use cases
- Updated EOS, Transport, and GasModel to accept PhysicsConstants and StateLayout as parameters
- Introduced new Device/Kernels.hpp header to centralize MFEM device-related includes
- Added Flow.hpp with flow physics helper functions
- Added new tests for entropy state transformations and state view functionality
- Updated build system to include Device directory

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/Device/Kernels.hpp | New header centralizing MFEM device macros and real_t definition |
| src/Physics/Kernels.hpp | Removed (replaced by Device/Kernels.hpp) |
| src/Physics/Physics.hpp | Updated includes to use Kernels.hpp, removed redundant MFEM includes |
| src/Physics/GasState.hpp | Major refactor: state views now accept StateLayout as parameter; added RW and primitive views; added eq_mom0 field |
| src/Physics/EOS.hpp | Updated all methods to accept PhysicsConstants and StateLayout as parameters; added entropy state methods |
| src/Physics/Transport.hpp | Updated to accept PhysicsConstants and StateLayout as parameters; removed member storage |
| src/Physics/GasModel.hpp | Stores PhysicsConstants and StateLayout as members; updated all method signatures |
| src/Physics/Flow.hpp | New file with flow physics helper functions (Riemann, boundary conditions, primitive conversions) |
| tests/*.cpp | Updated all test files to match new API signatures |
| tests/test_helpers.hpp | Added mfem.hpp include |
| tests/gas_state_adapter.hpp | Updated to use new state view API |
| CMakeLists.txt | Added Device directory to include paths |
| tests/CMakeLists.txt | Added Device directory to test include paths |
</details>


##### (copilot-generated)