### PR TITLE
Refactor to use new GasModel

### DIFF
--- a/src/BasicOperations/BasicOperations.cpp
+++ b/src/BasicOperations/BasicOperations.cpp
@@ -66,7 +66,6 @@ real_t ComputeTotalEnthalpy(const Vector &state, real_t gammaM1)
 void Conserv2Entropy(const DenseMatrix &vdof_mat, DenseMatrix &ent_mat, real_t gamma, real_t gammaM1, real_t gammaM1Inverse)
 {
     ent_mat = 0.0;
-    real_t s, beta;
     Vector state, ent_state(vdof_mat.Width());
     for (int d = 0; d < vdof_mat.Height(); d++)
     {
@@ -168,6 +167,7 @@ void EntropyGrad2PrimGrad(const DenseMatrix &vdof_mat, DenseMatrix &grad, real_t
     }
 }
 
+
 void Conserv2Prim(const Vector &state, Vector &prim_state, real_t gammaM1)
 {
     prim_state.SetSize(state.Size());
@@ -178,13 +178,13 @@ void Conserv2Prim(const Vector &state, Vector &prim_state, real_t gammaM1)
         prim_state(2) = state(2) / state(0);
         if (state.Size() > 4)
         {
-            prim_state(3) = state(3) / state(0);
+          prim_state(3) = state(3) / state(0);
         }
     }
     prim_state(state.Size() - 1) = ComputePressure(state, gammaM1);
 }
 
-void Prim2Conserv(const Vector &state, Vector &conserv_state, real_t gammaM1Inverse)
+  void Prim2Conserv(const Vector &state, Vector &conserv_state, real_t gammaM1Inverse)
 {
     conserv_state.SetSize(state.Size());
     conserv_state(0) = state(0);
@@ -238,7 +238,7 @@ void RotateState(Vector &state, const Vector &nor)
 {
     MFEM_ASSERT(nor.Size() > 1, "Rotate only in 2D or 3D");
     MFEM_ASSERT(nor.Size() < 4, "Rotate only in 2D or 3D");
-
+ 
     Vector tan1;
     Vector rhoV(state.GetData() + 1, nor.Size());
 
@@ -255,6 +255,32 @@ void RotateState(Vector &state, const Vector &nor)
 
     rhoV(0) = rho_u;
     rhoV(1) = rho_v;
+}
+
+void RotateState(const StateLayout &layout, Vector &state, const Vector &nor)
+{
+  int dim = nor.Size();
+  MFEM_ASSERT(dim >= 1 and dim < 4, "RotateState: Invalid normal dimension");
+  
+  Prandtl::PointStateViewRW S{state.GetData()};
+  if(nor.Size() == 1){
+    S.set_momentum(layout, 0, S.momentum(layout, 0)*nor(0));
+    return;
+  }
+  Vector tan1;
+  Vector rhoV(state.GetData() + layout.eq_mom[0], dim);
+  Normal(nor, tan1);
+  real_t rho_u = rhoV * nor;
+  real_t rho_v = rhoV * tan1;
+
+  if (dim == 3)
+    {
+      Vector tan2;
+      Cross(nor, tan1, tan2);
+      rhoV(2) = rhoV * tan2;
+    }
+  rhoV(0) = rho_u;
+  rhoV(1) = rho_v;
 }
 
 void RotateBack(Vector &state, const Vector &nor)
@@ -282,6 +308,32 @@ void RotateBack(Vector &state, const Vector &nor)
     rhoV(1) = rho_v;
 }
 
+void RotateBack(Vector &state, const Vector &nor, const StateLayout &layout)
+{
+  int dim = nor.Size();
+  MFEM_ASSERT(dim >= 1 and dim < 4, "RotateBack: Invalid normal dimension");
+  Vector rhoV(state.GetData() + layout.eq_mom[0], nor.Size());
+  if (dim == 1){
+    rhoV(0) = rhoV(0) / nor(0);
+    return;
+  }
+  Vector tan1;
+  Normal(nor, tan1);
+  real_t rho_u = rhoV(0) * nor(0) + rhoV(1) * tan1(0);
+  real_t rho_v = rhoV(0) * nor(1) + rhoV(1) * tan1(1);
+
+    if (dim == 3)
+    {
+        Vector tan2;
+        Cross(nor, tan1, tan2);
+        rho_u += rhoV(2) * tan2(0);
+        rho_v += rhoV(2) * tan2(1);
+        rhoV(2) = rhoV(0) * nor(2) + rhoV(1) * tan1(2) + rhoV(2) * tan2(2);
+    }
+
+    rhoV(0) = rho_u;
+    rhoV(1) = rho_v;
+}
 
 Vector ComputeRoeAverage(const Vector &state1, const Vector &state2, const real_t gammaM1)
 {

--- a/src/BasicOperations/BasicOperations.hpp
+++ b/src/BasicOperations/BasicOperations.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mfem.hpp"
+#include "GasState.hpp"
 
 namespace Prandtl
 {
@@ -33,22 +34,75 @@ namespace Prandtl
     void Conserv2Entropy(const Vector &state, Vector &ent_state, real_t gamma, real_t gammaM1, real_t gammaM1Inverse);
     void EntropyGrad2PrimGrad(const DenseMatrix &vdof_mat, DenseMatrix &grad, real_t gammaM1, real_t gammaM1Inverse);
     void Entropy2Conserv(const Vector &ent_state, Vector &state, real_t gamma, real_t gammaM1, real_t gammaM1Inverse);
-    void Conserv2Prim(const Vector &state, Vector &prim_state, real_t gammaM1);
     void Prim2Conserv(const Vector &state, Vector &conserv_state, real_t gammaM1Inverse);
+    void Conserv2Prim(const Vector &state, Vector &prim_state, real_t gammaM1);
 
     inline void Normalize(Vector &vec)
     {
         vec /= vec.Norml2();
     }
 
-    void Cross(const Vector &vec1, const Vector &vec2, Vector &cross);
-    void Normal(const Vector &vec, Vector &nor);
-    void RotateState(Vector &state, const Vector &nor);
-    void RotateBack(Vector &state, const Vector &nor);
+  void Cross(const Vector &vec1, const Vector &vec2, Vector &cross);
+  void Normal(const Vector &vec, Vector &nor);
+  void RotateState(const StateLayout &layout, Vector &state, const Vector &nor);
+  void RotateState(Vector &state, const Vector &nor);
+  void RotateBack(Vector &state, const Vector &nor);
+  void RotateBack(Vector &state, const Vector &nor, const StateLayout &layout);
 
     Vector ComputeRoeAverage(const Vector &state1, const Vector &state2, const real_t gamma);
-
+  
     const Table& ElementIndextoBdrElementIndex(Mesh &mesh);
-
+  
+  template<typename GasModelT>
+  inline void Conserv2Entropy(const GasModelT &gasModel, const Vector &state, Vector &ent_state)
+  {
+    PointStateView S{state.GetData()};
+    PointStateViewRW E{ent_state.GetData()};
+    gasModel.entropy_state(S, E);
+  }
+  
+  template<typename GasModelT>
+  inline void Conserv2Entropy(const GasModelT &gasModel, const DenseMatrix &vdof_mat, DenseMatrix &ent_mat)
+  {
+    ent_mat = 0.0;
+    real_t s, beta;
+    Vector state, ent_state(vdof_mat.Width());
+    for (int d = 0; d < vdof_mat.Height(); d++)
+      {
+        vdof_mat.GetRow(d, state);
+        Conserv2Entropy(gasModel, state, ent_state);
+        ent_mat.SetRow(d, ent_state);
+      }
+  }
+  
+  template<typename GasModelT>
+  inline void EntropyGrad2PrimGrad(const GasModelT &gasModel, const DenseMatrix &vdof_mat, DenseMatrix &grad)
+  {
+    Vector state, grad_state;
     
+    int numeq = gasModel.num_equations();
+    
+    Vector gradPrim(numeq);
+    
+    Prandtl::PointStateViewRW dPrim{gradPrim.GetData()};
+    
+    for (int d = 0; d < vdof_mat.Height(); d++)
+      {
+        vdof_mat.GetRow(d, state);
+        grad.GetRow(d, grad_state);
+        Prandtl::PointStateView S{state.GetData()};
+        Prandtl::PointStateView dS{grad_state.GetData()};
+        gasModel.grad_entropy_to_grad_prim(S, dS, dPrim);
+        grad.SetRow(d, gradPrim);
+      }
+  }
+  
+  template<typename GasModelT> 
+  inline void Entropy2Conserv(const GasModelT &gasModel, const Vector &ent_state, Vector &state)
+  {
+    Prandtl::PointStateView Se{ent_state.GetData()};
+    Prandtl::PointStateViewRW Sc{state.GetData()};
+    gasModel.entropy_to_conserved(Se, Sc);
+  }
+
 }

--- a/src/BasicOperations/BasicOperations.hpp
+++ b/src/BasicOperations/BasicOperations.hpp
@@ -65,7 +65,6 @@ namespace Prandtl
   inline void Conserv2Entropy(const GasModelT &gasModel, const DenseMatrix &vdof_mat, DenseMatrix &ent_mat)
   {
     ent_mat = 0.0;
-    real_t s, beta;
     Vector state, ent_state(vdof_mat.Width());
     for (int d = 0; d < vdof_mat.Height(); d++)
       {

--- a/src/Fluxes/NavierStokesFlux.cpp
+++ b/src/Fluxes/NavierStokesFlux.cpp
@@ -4,21 +4,20 @@
 namespace Prandtl
 {
 
-real_t NavierStokesFlux::ComputeInviscidFlux(const Vector &state, ElementTransformation &Tr, DenseMatrix &flux) const
-{
-    return ComputeFlux(state, Tr, flux);
-}
-
-void NavierStokesFlux::ComputeViscousFlux(const Vector &state, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, DenseMatrix &flux) const
-{
-    Conserv2Prim(state, prim, gammaM1);
-
+  void NavierStokesFlux::ComputeViscousFlux(const Vector &state, const Vector &dqdx, const Vector &dqdy,
+                                            const Vector &dqdz, DenseMatrix &flux) const
+  {
+    PointStateView S{state.GetData()};
+    real_t mu = gasModel.viscosity(S);
+    real_t kappa = gasModel.thermal_conductivity(S);
+    real_t mu_bulk_loc = gasModel.bulk_viscosity(S);    
+    
     const real_t &drdx = dqdx(0);
     const real_t &dudx = dqdx(1);
     const real_t &dvdx = dqdx(2);
     const real_t &dwdx = dqdx(3);
     const real_t &dpdx = dqdx(4);
-
+    
     const real_t &drdy = dqdy(0);
     const real_t &dudy = dqdy(1);
     const real_t &dvdy = dqdy(2);
@@ -31,88 +30,180 @@ void NavierStokesFlux::ComputeViscousFlux(const Vector &state, const Vector &dqd
     const real_t &dwdz = dqdz(3);
     const real_t &dpdz = dqdz(4);
 
-#ifdef SUTHERLAND
-    mu = ComputeViscosity(prim(0), prim(num_equations - 1));
-#endif
+    const real_t grad_rho[3] = {drdx, drdy, drdz};
+    const real_t grad_p[3] = {dpdx, dpdy, dpdz};
+    real_t grad_t[3] = {0.0, 0.0, 0.0};
 
-    lambda = mu * gamma * PrInverse;
-    div = dudx + dvdy + dwdz;
-    cv_dTdx = gammaM1Inverse / prim(0) * (dpdx - prim(num_equations - 1) / prim(0) * drdx);
-    cv_dTdy = gammaM1Inverse / prim(0) * (dpdy - prim(num_equations - 1) / prim(0) * drdy);
-    cv_dTdz = gammaM1Inverse / prim(0) * (dpdz - prim(num_equations - 1) / prim(0) * drdz);
+    real_t vx = gasModel.velocity(S, 0);
+    real_t vy = gasModel.velocity(S, 1);
+    real_t vz = gasModel.velocity(S, 2);
 
-    flux(1, 0) = mu * (2.0 * dudx - mu_bulk * div);
+    gasModel.grad_temperature(S, grad_rho, grad_p, grad_t);
+
+    real_t div = dudx + dvdy + dwdz;
+
+    flux(1, 0) = mu * (2.0 * dudx - mu_bulk_loc * div);
     flux(2, 0) = mu * (dudy + dvdx);
     flux(3, 0) = mu * (dudz + dwdx);
-    flux(4, 0) = prim(1) * flux(1, 0) + prim(2) * flux(2, 0) + prim(3) * flux(3, 0) + lambda * cv_dTdx;
+    flux(4, 0) = vx * flux(1, 0) + vy * flux(2, 0) + vz * flux(3, 0) + kappa * grad_t[0];
 
     flux(1, 1) = mu * (dvdx + dudy);
-    flux(2, 1) = mu * (2.0 * dvdy - mu_bulk * div);
+    flux(2, 1) = mu * (2.0 * dvdy - mu_bulk_loc * div);
     flux(3, 1) = mu * (dvdz + dwdy);
-    flux(4, 1) = prim(1) * flux(1, 1) + prim(2) * flux(2, 1) + prim(3) * flux(3, 1) + lambda * cv_dTdy;
+    flux(4, 1) = vx * flux(1, 1) + vy * flux(2, 1) + vz * flux(3, 1) + kappa * grad_t[1];
 
     flux(1, 2) = mu * (dwdx + dudz);
     flux(2, 2) = mu * (dwdy + dvdz);
-    flux(3, 2) = mu * (2.0 * dwdz - mu_bulk * div);
-    flux(4, 2) = prim(1) * flux(1, 2) + prim(2) * flux(2, 2) + prim(3) * flux(3, 2) + lambda * cv_dTdz; 
-}
-
-void NavierStokesFlux::ComputeViscousFlux(const Vector &state, const Vector &dqdx, const Vector &dqdy, DenseMatrix &flux) const
-{
-    Conserv2Prim(state, prim, gammaM1);
-
+    flux(3, 2) = mu * (2.0 * dwdz - mu_bulk_loc * div);
+    flux(4, 2) = vx * flux(1, 2) + vy * flux(2, 2) + vz * flux(3, 2) + kappa * grad_t[2]; 
+  }
+  
+  void NavierStokesFlux::ComputeViscousFlux(const Vector &state, const Vector &dqdx,
+                                            const Vector &dqdy, DenseMatrix &flux) const
+  {
+    PointStateView S{state.GetData()};
+    real_t kappa = gasModel.thermal_conductivity(S);
+    real_t mu = gasModel.viscosity(S);
+    real_t mu_bulk_loc = gasModel.bulk_viscosity(S);    
+    real_t press = gasModel.pressure(S);
+    
     const real_t &drdx = dqdx(0);
     const real_t &dudx = dqdx(1);
     const real_t &dvdx = dqdx(2);
     const real_t &dpdx = dqdx(3);
-
+    
     const real_t &drdy = dqdy(0);
     const real_t &dudy = dqdy(1);
     const real_t &dvdy = dqdy(2);
     const real_t &dpdy = dqdy(3);
 
-#ifdef SUTHERLAND
-    mu = ComputeViscosity(prim(0), prim(num_equations - 1));
-#endif
+    const real_t grad_rho[2] = {drdx, drdy};
+    const real_t grad_p[2] = {dpdx, dpdy};
+    real_t grad_t[2] = {0.0, 0.0};
+    real_t vx = gasModel.velocity(S, 0);
+    real_t vy = gasModel.velocity(S, 1);
+    real_t rho = gasModel.density(S);
 
-    lambda = mu * gamma * PrInverse;
-    div = dudx + dvdy;
-    cv_dTdx = gammaM1Inverse / prim(0) * (dpdx - prim(num_equations - 1) / prim(0) * drdx);
-    cv_dTdy = gammaM1Inverse / prim(0) * (dpdy - prim(num_equations - 1) / prim(0) * drdy);
+    gasModel.grad_temperature(S, grad_rho, grad_p, grad_t);
+    real_t div = dudx + dvdy;
 
-    flux(1, 0) = mu * (2.0 * dudx - mu_bulk * div);
+    flux(1, 0) = mu * (2.0 * dudx - mu_bulk_loc * div);
     flux(2, 0) = mu * (dudy + dvdx);
-    flux(3, 0) = prim(1) * flux(1, 0) + prim(2) * flux(2, 0) + lambda * cv_dTdx;
+    flux(3, 0) = vx * flux(1, 0) + vy * flux(2, 0) + kappa * grad_t[0];
 
     flux(1, 1) = mu * (dvdx + dudy);
-    flux(2, 1) = mu * (2.0 * dvdy - mu_bulk * div);
-    flux(3, 1) = prim(1) * flux(1, 1) + prim(2) * flux(2, 1) + lambda * cv_dTdy;
+    flux(2, 1) = mu * (2.0 * dvdy - mu_bulk_loc * div);
+    flux(3, 1) = vx * flux(1, 1) + vy * flux(2, 1) + kappa * grad_t[1];
 }
 
-void NavierStokesFlux::ComputeViscousFlux(const Vector &state, const Vector &dqdx, DenseMatrix &flux) const
-{
-    Conserv2Prim(state, prim, gammaM1);
-
+  void NavierStokesFlux::ComputeViscousFlux(const Vector &state, const Vector &dqdx, DenseMatrix &flux) const
+  {
+    PointStateView S{state.GetData()};
+    real_t kappa = gasModel.thermal_conductivity(S);
+    real_t mu = gasModel.viscosity(S);
+    real_t mu_bulk_loc = gasModel.bulk_viscosity(S);    
+    
     const real_t &drdx = dqdx(0);
     const real_t &dudx = dqdx(1);
     const real_t &dpdx = dqdx(2);
+    
+    const real_t grad_rho[1] = {drdx};
+    const real_t grad_p[1] = {dpdx};
+    real_t grad_t[1] = {0.0};
+    real_t vx = gasModel.velocity(S, 0);
+    gasModel.grad_temperature(S, grad_rho, grad_p, grad_t);
+    real_t div = dudx;
+    
+    flux(1, 0) = mu * (2.0 * dudx - mu_bulk_loc * div);
+    flux(2, 0) = vx * flux(1, 0) + kappa * grad_t[0];
+  }
+  
+  real_t NavierStokesFlux::ComputeFlux(const Vector &U,
+                                       ElementTransformation &Tr,
+                                       DenseMatrix &FU) const
+  {
+    
+    PointStateView S{U.GetData()};
+    
+    // 1. Get states
+    const real_t density = gasModel.density(S);
+    const Vector momentum(U.GetData()+gasModel.L.eq_mom0, dim);
+    const real_t energy = gasModel.energy(S);
+    const real_t pressure = gasModel.pressure(S);
+    const real_t ke = gasModel.kinetic_energy_density(S);
+    
+    // Check whether the solution is physical only in debug mode
+    MFEM_ASSERT(density >= 0, "Negative Density");
+    MFEM_ASSERT(pressure >= 0, "Negative Pressure");
+    MFEM_ASSERT(energy >= 0, "Negative Energy");
+    
+    // 2. Compute Flux
+    for (int d = 0; d < dim; d++)
+      {
+        FU(0, d) = momentum(d);  // ρu
+        for (int i = 0; i < dim; i++)
+          {
+            // ρuuᵀ
+            FU(1 + i, d) = momentum(i) * momentum(d) / density;
+          }
+        // (ρuuᵀ) + p
+        FU(1 + d, d) += pressure;
+      }
+    // enthalpy H = e + p/ρ = (E + p)/ρ
+    const real_t H = (energy + pressure) / density;
+    for (int d = 0; d < dim; d++)
+      {
+        // u(E+p) = ρu*(E + p)/ρ = ρu*H
+        FU(1 + dim, d) = momentum(d) * H;
+      }
+    
+    // 3. Compute maximum characteristic speed
+    
+    const real_t sound = gasModel.sound_speed(S);
+    // fluid speed |u|
+    const real_t speed = std::sqrt(2.0 * ke / density);
+    // max characteristic speed = fluid speed + sound speed
+    return speed + sound;
+  }
+  
+  
+  real_t NavierStokesFlux::ComputeFluxDotN(const Vector &x,
+                                           const Vector &normal,
+                                           FaceElementTransformations &Tr,
+                                           Vector &FUdotN) const
+  {
+    PointStateView S{x.GetData()};
 
-#ifdef SUTHERLAND
-    mu = ComputeViscosity(prim(0), prim(num_equations - 1));
-#endif
-
-    lambda = mu * gamma * PrInverse;
-    div = dudx;
-    cv_dTdx = gammaM1Inverse / prim(0) * (dpdx - prim(num_equations - 1) / prim(0) * drdx);
-
-    flux(1, 0) = mu * (2.0 * dudx - mu_bulk * div);
-    flux(2, 0) = prim(1) * flux(1, 0) + lambda * cv_dTdx;
-}
-
-real_t NavierStokesFlux::ComputeInviscidFluxDotN(const Vector &x, const Vector &nor, FaceElementTransformations &Tr, Vector &fluxN) const
-{
-    return ComputeFluxDotN(x, nor, Tr, fluxN);
-}
-
+    // 1. Get states
+    const real_t density = gasModel.density(S);
+    const Vector momentum(x.GetData()+gasModel.L.eq_mom0, dim);  // ρu
+    const real_t energy = gasModel.energy(S);
+    const real_t kinetic_energy = gasModel.kinetic_energy_density(S);
+    const real_t pressure = gasModel.pressure(S);
+    
+    // Check whether the solution is physical only in debug mode
+    MFEM_ASSERT(density >= 0, "Negative Density");
+    MFEM_ASSERT(pressure >= 0, "Negative Pressure");
+    MFEM_ASSERT(energy >= 0, "Negative Energy");
+    
+    // 2. Compute normal flux
+    FUdotN(0) = momentum * normal;  // ρu⋅n
+    // u⋅n
+    const real_t normal_velocity = FUdotN(0) / density;
+    for (int d = 0; d < dim; d++)
+      {
+        // (ρuuᵀ + pI)n = ρu*(u⋅n) + pn
+        FUdotN(1 + d) = normal_velocity * momentum(d) + pressure * normal(d);
+      }
+    // (u⋅n)(E + p)
+    FUdotN(1 + dim) = normal_velocity * (energy + pressure);
+    
+    // 3. Compute maximum characteristic speed
+    const real_t sound = gasModel.sound_speed(S);
+    // fluid speed |u|
+    const real_t speed = std::fabs(normal_velocity) / std::sqrt(normal*normal);
+    // max characteristic speed = fluid speed + sound speed
+    return speed + sound;
+  }
 
 }

--- a/src/Fluxes/NavierStokesFlux.cpp
+++ b/src/Fluxes/NavierStokesFlux.cpp
@@ -64,8 +64,7 @@ namespace Prandtl
     PointStateView S{state.GetData()};
     real_t kappa = gasModel.thermal_conductivity(S);
     real_t mu = gasModel.viscosity(S);
-    real_t mu_bulk_loc = gasModel.bulk_viscosity(S);    
-    real_t press = gasModel.pressure(S);
+    real_t mu_bulk_loc = gasModel.bulk_viscosity(S);
     
     const real_t &drdx = dqdx(0);
     const real_t &dudx = dqdx(1);
@@ -82,7 +81,6 @@ namespace Prandtl
     real_t grad_t[2] = {0.0, 0.0};
     real_t vx = gasModel.velocity(S, 0);
     real_t vy = gasModel.velocity(S, 1);
-    real_t rho = gasModel.density(S);
 
     gasModel.grad_temperature(S, grad_rho, grad_p, grad_t);
     real_t div = dudx + dvdy;

--- a/src/Fluxes/NavierStokesFlux.hpp
+++ b/src/Fluxes/NavierStokesFlux.hpp
@@ -1,39 +1,52 @@
 #pragma once
 
 #include "mfem.hpp"
+#include "GasModel.hpp"
 
 namespace Prandtl
 {
 
 using namespace mfem;
 
-class NavierStokesFlux : public EulerFlux
+class NavierStokesFlux : public FluxFunction
 {
 private:
-    mutable real_t div, cv_dTdx, cv_dTdy, cv_dTdz, lambda, mu;
-    mutable Vector prim;
-    const real_t gamma, gammaM1, gammaM1Inverse;
-    const real_t PrInverse;
-    const real_t mu_bulk, mu0, R_gas, Ts, T0, T0pTs;
-
+  const IdealGasModel gasModel;
 public:
-    NavierStokesFlux(const int dim, real_t gamma_, real_t Pr, real_t mu_, real_t mu0, real_t mu_bulk, real_t R_gas, real_t Ts, real_t T0)
-        : EulerFlux(dim, gamma_), gamma(gamma_), gammaM1(gamma - 1.0), gammaM1Inverse(1.0 / gammaM1), PrInverse(1.0 / Pr),
-          mu(mu_), mu0(mu0), mu_bulk(mu_bulk), R_gas(R_gas), Ts(Ts), T0(T0), T0pTs(T0 + Ts)
-    {
-        prim.SetSize(dim + 2);
-    }
-    real_t ComputeInviscidFlux(const Vector &state, ElementTransformation &Tr, DenseMatrix &flux) const;
-    void ComputeViscousFlux(const Vector &state, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, DenseMatrix &flux) const;
-    void ComputeViscousFlux(const Vector &state, const Vector &dqdx, const Vector &dqdy, DenseMatrix &flux) const;
-    void ComputeViscousFlux(const Vector &state, const Vector &dqdx, DenseMatrix &flux) const;
-    real_t ComputeInviscidFluxDotN(const Vector &x, const Vector &nor, FaceElementTransformations &Tr, Vector &fluxN) const;
+  explicit NavierStokesFlux(const IdealGasModel &gasModel_)
+    : FluxFunction(gasModel_.num_equations(), gasModel_.dim()), gasModel(gasModel_){};
+  void ComputeViscousFlux(const Vector &state, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, DenseMatrix &flux) const;
+  void ComputeViscousFlux(const Vector &state, const Vector &dqdx, const Vector &dqdy, DenseMatrix &flux) const;
+  void ComputeViscousFlux(const Vector &state, const Vector &dqdx, DenseMatrix &flux) const;
+  MFEM_HOST_DEVICE inline real_t pressure(const real_t *state) const
+  {
+    Prandtl::PointStateView S{state};
+    return gasModel.pressure(S);
+  }
 
-    inline real_t ComputeViscosity(real_t rho, real_t p)
-    {
-        real_t T = p / (rho * R_gas);
-        return mu0 * T0pTs / (T + Ts) * (T / T0) * std::sqrt(T / T0);
-    }
+  /**
+   * @brief Compute inviscid flux from conserved state
+   *
+   * @param state conserved state at current integration point
+   * @param Tr current element transformation with the integration point
+   * @param flux inviscid flux (ex, ideal single gas: F(ρ, ρu, E) = [ρuᵀ; ρuuᵀ + pI; uᵀ(E + p)])
+   * @return real_t maximum characteristic speed, c + |u| (c = speed of sound)
+   */
+  real_t ComputeFlux(const Vector &state, ElementTransformation &Tr,
+                     DenseMatrix &flux) const override;
+  
+  /**
+   * @brief Compute inviscid flux along normal
+   *
+   * @param x conserved state at current integration point
+   * @param normal normal vector, usually not a unit vector
+   * @param Tr current element transformation with the integration point
+   * @param fluxN inviscid flux dotted with normal
+   * @return real_t maximum characteristic speed, c + |u.n|
+   */
+  real_t ComputeFluxDotN(const Vector &x, const Vector &normal,
+                         FaceElementTransformations &Tr,
+                         Vector &fluxN) const override;
 };
-
+  
 }

--- a/src/Indicators/PerssonPeraireIndicator.cpp
+++ b/src/Indicators/PerssonPeraireIndicator.cpp
@@ -4,19 +4,20 @@
 namespace Prandtl
 {
 
-PerssonPeraireIndicator::PerssonPeraireIndicator(std::shared_ptr<ParFiniteElementSpace> vfes,
-                    std::shared_ptr<ParFiniteElementSpace> fes0,
-                    std::shared_ptr<ParGridFunction> eta,
-                    std::shared_ptr<ModalBasis> modalBasis, real_t gamma)
-                    : Indicator(vfes, fes0, eta), modalBasis(modalBasis),
-                    ubdegs(modalBasis->GetPolyDegs()), gammaM1(gamma - 1.0)
-{
+  PerssonPeraireIndicator::PerssonPeraireIndicator(std::shared_ptr<ParFiniteElementSpace> vfes,
+                                                   std::shared_ptr<ParFiniteElementSpace> fes0,
+                                                   std::shared_ptr<ParGridFunction> eta,
+                                                   std::shared_ptr<ModalBasis> modalBasis,
+                                                   const IdealGasModel &gasModel_)
+  : Indicator(vfes, fes0, eta), modalBasis(modalBasis), gasModel(gasModel_),
+    ubdegs(modalBasis->GetPolyDegs())
+  {
     rho_p.SetSize(ndofs);
     modes.SetSize(ndofs);
     modesM1.SetSize(ndofs);
     modesM2.SetSize(ndofs);
     ubdegs_row.SetSize(dim);
-}
+  }
 
 void PerssonPeraireIndicator::CheckSmoothness(const Vector &x)
 {
@@ -30,7 +31,8 @@ void PerssonPeraireIndicator::CheckSmoothness(const Vector &x)
         for (int i = 0; i < ndofs; i++)
         {
             vdof_mat.GetRow(i, state);
-            rho_p(i) = state(0) * ComputePressure(state, gammaM1);
+            Prandtl::PointStateView S{state.GetData()};
+            rho_p(i) = gasModel.density(S) * gasModel.pressure(S);
         }
         modalBasis->ComputeModes(rho_p, modes);
         modesM1 = modesM2 = modes;

--- a/src/Indicators/PerssonPeraireIndicator.hpp
+++ b/src/Indicators/PerssonPeraireIndicator.hpp
@@ -2,6 +2,7 @@
 
 #include "Indicator.hpp"
 #include "ModalBasis.hpp"
+#include "GasModel.hpp"
 
 namespace Prandtl
 {
@@ -9,15 +10,15 @@ namespace Prandtl
 class PerssonPeraireIndicator : public Indicator
 {
 private:
-    std::shared_ptr<ModalBasis> modalBasis;
-    Vector rho_p, modes, modesM1, modesM2;
-    Array2D<int> ubdegs;
-    Array<int> ubdegs_row;
-
-    real_t gammaM1;
+  std::shared_ptr<ModalBasis> modalBasis;
+  const IdealGasModel gasModel;
+  Vector rho_p, modes, modesM1, modesM2;
+  Array2D<int> ubdegs;
+  Array<int> ubdegs_row;
+  
 public:
-    PerssonPeraireIndicator(std::shared_ptr<ParFiniteElementSpace> vfes, std::shared_ptr<ParFiniteElementSpace> fes0, std::shared_ptr<ParGridFunction> eta, std::shared_ptr<ModalBasis> modalBasis, real_t gamma);
-    virtual void CheckSmoothness(const Vector &x) override;
+  PerssonPeraireIndicator(std::shared_ptr<ParFiniteElementSpace> vfes, std::shared_ptr<ParFiniteElementSpace> fes0, std::shared_ptr<ParGridFunction> eta, std::shared_ptr<ModalBasis> modalBasis, const IdealGasModel &gasModel_);
+  virtual void CheckSmoothness(const Vector &x) override;
 };
 
 }

--- a/src/Integrators/BoundaryConditions/BdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/BdrFaceIntegrator.cpp
@@ -5,14 +5,18 @@
 namespace Prandtl
 {
 
-bool debug_boundary = false;
-BdrFaceIntegrator::BdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme_, const NumericalFlux &rsolver, int Np, const real_t &time, real_t gamma_, bool constant, bool t_dependent)
-   : NonlinearFormIntegrator(), liftingScheme(liftingScheme_),
-     rsolver(rsolver), fluxFunction(rsolver.GetFluxFunction()),
-     Np_x(Np), GLIntRules(0, Quadrature1D::GaussLobatto), 
-     num_equations(fluxFunction.num_equations), dim(fluxFunction.dim),
-     time(time), gamma(gamma_), gammaM1(gamma - 1.0), gammaM1Inverse(1.0 / gammaM1),
-     constant(constant), t_dependent(t_dependent)
+constexpr bool debug_boundary = false;
+
+  BdrFaceIntegrator::BdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme_, const IdealGasModel &gasModel_,
+                                       const NumericalFlux &rsolver, int Np, const real_t &time, bool constant, bool t_dependent)
+    : NonlinearFormIntegrator(), gasModel(gasModel_),
+      liftingScheme(liftingScheme_),
+      rsolver(rsolver), fluxFunction(rsolver.GetFluxFunction()),
+      Np_x(Np), GLIntRules(0, Quadrature1D::GaussLobatto), 
+      num_equations(fluxFunction.num_equations), dim(fluxFunction.dim),
+      mass_eq(gasModel.L.eq_mass), mom_eq(gasModel.L.eq_mom[0]),
+      en_eq(gasModel.L.eq_energy), sc_eq(gasModel.L.eq_scalar0),
+      time(time), constant(constant), t_dependent(t_dependent)
 {
    const IntegrationRule *ir_vol;
 
@@ -58,7 +62,8 @@ BdrFaceIntegrator::BdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingSchem
    dU_face1.SetSize(num_equations);
 }
 
-void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr, const Vector &el_u, Vector &el_dudt)
+void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,
+                                           const Vector &el_u, Vector &el_dudt)
 {
    if (debug_boundary) // && (time >= 2.99999 || time == 0))
    {
@@ -174,7 +179,9 @@ void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const Finit
    }   
 }
 
-void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr, const Vector &el_u, const Vector &el_dudx, const Vector &el_dudy, Vector &el_dudt)
+void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2,
+                                           FaceElementTransformations &Tr, const Vector &el_u,
+                                           const Vector &el_dudx, const Vector &el_dudy, Vector &el_dudt)
 {
    el_dudt.SetSize(dof1 * num_equations);
    el_dudt = 0.0;
@@ -208,7 +215,8 @@ void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const Finit
    }   
 }
 
-void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr, const Vector &el_u, const Vector &el_dudx, Vector &el_dudt)
+void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr,
+                                           const Vector &el_u, const Vector &el_dudx, Vector &el_dudt)
 {
    const int dof1 = el1.GetDof();
 
@@ -244,12 +252,14 @@ void BdrFaceIntegrator::AssembleFaceVector(const FiniteElement &el1, const Finit
    }   
 }
 
-void BdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip)
+void BdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr,
+                                                  const IntegrationPoint &ip)
 {
    mfem_error("BdrFaceIntegrator::ComputeOuterInviscidState() is not overridden!");
 }
 
-real_t BdrFaceIntegrator::ComputeBdrFaceInviscidFlux(const Vector &state1, Vector &state2, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
+real_t BdrFaceIntegrator::ComputeBdrFaceInviscidFlux(const Vector &state1, Vector &state2, Vector &fluxN, const Vector &nor,
+                                                     FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {
    ComputeOuterInviscidState(state1, state2, Tr, ip);
    // Compute F(u+, x) and F(u-, x) with maximum characteristic speed
@@ -257,28 +267,35 @@ real_t BdrFaceIntegrator::ComputeBdrFaceInviscidFlux(const Vector &state1, Vecto
    return rsolver.ComputeFaceFlux(state1, state2, nor, fluxN);
 }
 
-void BdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
+void BdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx,
+                                                  const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor,
+                                                  FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {
    mfem_error("BdrFaceIntegrator::ComputeBdrFaceViscousFlux() is not overridden!");
 }
 
-void BdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
+void BdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx,
+                                                  const Vector &dqdy, Vector &fluxN, const Vector &nor,
+                                                  FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {
    mfem_error("BdrFaceIntegrator::ComputeBdrFaceViscousFlux() is not overridden!");
 }
 
-void BdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
+void BdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx,
+                                                  Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr,
+                                                  const IntegrationPoint &ip)
 {
    mfem_error("BdrFaceIntegrator::ComputeBdrFaceViscousFlux() is not overridden!");
 }
 
-void BdrFaceIntegrator::ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr, const IntegrationPoint &ip)
-{
-   Entropy2Conserv(state1, conserv_state, gamma, gammaM1, gammaM1Inverse);
-   ComputeOuterInviscidState(conserv_state, state2, Tr, ip);
-   Conserv2Entropy(state2, fluxN, gamma, gammaM1, gammaM1Inverse);
-   fluxN -= state1;
-   fluxN *= 0.5; 
-}
-
+  void BdrFaceIntegrator::ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr,
+                                                    const IntegrationPoint &ip)
+  {
+    Entropy2Conserv(gasModel, state1, conserv_state);
+    ComputeOuterInviscidState(conserv_state, state2, Tr, ip);
+    Conserv2Entropy(gasModel, state2, fluxN);
+    fluxN -= state1;
+    fluxN *= 0.5; 
+  }
+  
 }

--- a/src/Integrators/BoundaryConditions/BdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/BdrFaceIntegrator.hpp
@@ -38,21 +38,22 @@ private:
    std::shared_ptr<ParGridFunction> u_gf;
 
 protected:
-   Vector nor;     // normal vector, @see CalcOrtho
-   const NavierStokesFlux fluxFunction;
-   const int num_equations, dim;
-   DenseMatrix flux_mat;
-   const real_t &time;
-   bool constant, t_dependent;
-   Vector dqdx, dqdy, dqdz;
-   std::shared_ptr<LiftingScheme> liftingScheme;
-   const NumericalFlux &rsolver;  // Numerical flux that maps F(u±,x) to hat(F)
-   bool scaleStateInAxisymm = true;
-
-   const real_t gamma, gammaM1, gammaM1Inverse;
+  Vector nor;     // normal vector, @see CalcOrtho
+  const NavierStokesFlux fluxFunction;
+  const int num_equations, dim;
+  DenseMatrix flux_mat;
+  const real_t &time;
+  bool constant, t_dependent;
+  Vector dqdx, dqdy, dqdz;
+  std::shared_ptr<LiftingScheme> liftingScheme;
+  const IdealGasModel gasModel;
+  const NumericalFlux &rsolver;  // Numerical flux that maps F(u±,x) to hat(F)
+  bool scaleStateInAxisymm = true;
+  const int mass_eq, mom_eq, en_eq, sc_eq; 
 
 public:
-   BdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, int Np, const real_t &time, real_t gamma, bool constant, bool t_dependent);
+  BdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const IdealGasModel &gasModel_,
+                    const NumericalFlux &rsolver, int Np, const real_t &time, bool constant, bool t_dependent);
    
    void ResetMaxCharSpeed()
    {

--- a/src/Integrators/BoundaryConditions/NoSlipAdiabWallBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/NoSlipAdiabWallBdrFaceIntegrator.cpp
@@ -3,17 +3,19 @@
 namespace Prandtl
 {
 
-NoSlipAdiabWallBdrFaceIntegrator::NoSlipAdiabWallBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, FunctionCoefficient &qn_wall_, VectorFunctionCoefficient &V_wall_,
-    bool t_dependent)
-    : SlipWallBdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
-    qn_wall(qn_wall_), V_wall(V_wall_) {}
-
-NoSlipAdiabWallBdrFaceIntegrator::NoSlipAdiabWallBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, real_t qn, const Vector &V)
-    : SlipWallBdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, true, false),
+NoSlipAdiabWallBdrFaceIntegrator::NoSlipAdiabWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, 
+                                                                   const IdealGasModel &gasModel_,
+                                                                   const NumericalFlux &rsolver, const int Np,
+                                                                   const real_t &time, FunctionCoefficient &qn_wall_,
+                                                                   VectorFunctionCoefficient &V_wall_,bool t_dependent)
+: SlipWallBdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
+  qn_wall(qn_wall_), V_wall(V_wall_) {}
+  
+  NoSlipAdiabWallBdrFaceIntegrator::NoSlipAdiabWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                   const IdealGasModel &gasModel_,
+                                                                   const NumericalFlux &rsolver, const int Np,
+                                                                   const real_t &time, real_t qn, const Vector &V)
+  : SlipWallBdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false),
     qn(qn), V(V),
     qn_wall(std::function<real_t(const Vector&)>()), V_wall(dim, std::function<void(const Vector &, Vector&)>()) {}
 
@@ -32,7 +34,7 @@ void NoSlipAdiabWallBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &s
 
     fluxFunction.ComputeViscousFlux(state1, dqdx, dqdy, dqdz,  flux_mat);
     flux_mat.Mult(nor, fluxN);
-    fluxN(num_equations - 1) = V(0) * fluxN(1) + V(1) * fluxN(2) + V(2) * fluxN(3) + qn;
+    fluxN(en_eq) = V(0) * fluxN(mom_eq) + V(1) * fluxN(mom_eq+1) + V(2) * fluxN(mom_eq+2) + qn;
 }
 
 void NoSlipAdiabWallBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
@@ -50,7 +52,7 @@ void NoSlipAdiabWallBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &s
 
     fluxFunction.ComputeViscousFlux(state1, dqdx, dqdy, flux_mat);
     flux_mat.Mult(nor, fluxN);
-    fluxN(num_equations - 1) = V(0) * fluxN(1) + V(1) * fluxN(2) + qn;
+    fluxN(en_eq) = V(0) * fluxN(mom_eq) + V(1) * fluxN(mom_eq+1) + qn;
 }
 
 void NoSlipAdiabWallBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
@@ -68,7 +70,7 @@ void NoSlipAdiabWallBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &s
 
     fluxFunction.ComputeViscousFlux(state1, dqdx, flux_mat);
     flux_mat.Mult(nor, fluxN);
-    fluxN(num_equations - 1) = V(0) * fluxN(1) + qn;
+    fluxN(en_eq) = V(0) * fluxN(mom_eq) + qn;
 }
 
 void NoSlipAdiabWallBdrFaceIntegrator::ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr, const IntegrationPoint &ip)
@@ -78,18 +80,19 @@ void NoSlipAdiabWallBdrFaceIntegrator::ComputeBdrFaceLiftingFlux(const Vector &s
         V_wall.SetTime(time);
         V_wall.Eval(V, Tr, ip);        
     }
-    v = -state1(num_equations - 1);
-    fluxN(0) = state1(0);
-    fluxN(1) = V(0) * v;
+    Prandtl::PointStateView S{state1.GetData()};
+    v = -gasModel.energy(S);
+    fluxN(mass_eq) = gasModel.mass(S);
+    fluxN(mom_eq) = V(0) * v;
     if (dim > 1)
     {
-        fluxN(2) = V(1) * v;
+        fluxN(mom_eq+1) = V(1) * v;
         if (dim > 2)
         {
-            fluxN(3) = V(2) * v;
+            fluxN(mom_eq+2) = V(2) * v;
         }
     }
-    fluxN(num_equations - 1) = -v;
+    fluxN(en_eq) = -v;
     fluxN -= state1;
 }
 

--- a/src/Integrators/BoundaryConditions/NoSlipAdiabWallBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/NoSlipAdiabWallBdrFaceIntegrator.hpp
@@ -15,13 +15,25 @@ private:
     FunctionCoefficient qn_wall;
     VectorFunctionCoefficient V_wall;
 public:
-    NoSlipAdiabWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, FunctionCoefficient &qn_wall, VectorFunctionCoefficient &V_wall, bool t_dependent = false);
-    NoSlipAdiabWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,  const real_t &time, real_t gamma, real_t qn, const Vector &V);
-
-    virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
-    virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
-    virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
-    virtual void ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
+  NoSlipAdiabWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const IdealGasModel &gasModel_,
+                                   const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                   FunctionCoefficient &qn_wall, VectorFunctionCoefficient &V_wall,
+                                   bool t_dependent = false);
+  NoSlipAdiabWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const IdealGasModel &gasModel_,
+                                   const NumericalFlux &rsolver, const int Np, const real_t &time, real_t qn,
+                                   const Vector &V);
+    virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx,
+                                           const Vector &dqdy, const Vector &dqdz, Vector &fluxN,
+                                           const Vector &nor, FaceElementTransformations &Tr,
+                                           const IntegrationPoint &ip) override;
+    virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx,
+                                           const Vector &dqdy, Vector &fluxN, const Vector &nor,
+                                           FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
+    virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx,
+                                           Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr,
+                                           const IntegrationPoint &ip) override;
+    virtual void ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr,
+                                           const IntegrationPoint &ip) override;
 };
 
 }

--- a/src/Integrators/BoundaryConditions/NoSlipIsothWallBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/NoSlipIsothWallBdrFaceIntegrator.cpp
@@ -1,24 +1,26 @@
 #include "NoSlipIsothWallBdrFaceIntegrator.hpp"
+#include "Flow.hpp"
 
 namespace Prandtl
 {
 
-NoSlipIsothWallBdrFaceIntegrator::NoSlipIsothWallBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, real_t R_gas_, FunctionCoefficient &T_wall_, VectorFunctionCoefficient &V_wall_,
-    bool t_dependent)
-    : SlipWallBdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
-    T_wall(T_wall_), V_wall(V_wall_), R_gas(R_gas_) {}
-
-NoSlipIsothWallBdrFaceIntegrator::NoSlipIsothWallBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, real_t R_gas_, real_t &T, const Vector &V)
-    : SlipWallBdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, true, false),
-    T(T), V(V), T_wall(std::function<real_t(const Vector&)>()), V_wall(dim, std::function<void(const Vector&, Vector&)>()), R_gas(R_gas_)
-{
-    v = 1.0 / (R_gas * T);
-}
-
+NoSlipIsothWallBdrFaceIntegrator::NoSlipIsothWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                   const IdealGasModel &gasModel_,
+                                                                   const NumericalFlux &rsolver, const int Np,
+                                                                   const real_t &time,
+                                                                   FunctionCoefficient &T_wall_, VectorFunctionCoefficient &V_wall_,
+                                                                   bool t_dependent)
+: SlipWallBdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
+  T_wall(T_wall_), V_wall(V_wall_) {}
+  
+NoSlipIsothWallBdrFaceIntegrator::NoSlipIsothWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                   const IdealGasModel &gasModel_,
+                                                                   const NumericalFlux &rsolver, const int Np,
+                                                                   const real_t &time, real_t &T, const Vector &V)
+: SlipWallBdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false),
+  T(T), V(V), T_wall(std::function<real_t(const Vector&)>()), V_wall(dim, std::function<void(const Vector&, Vector&)>())
+{}
+  
 void NoSlipIsothWallBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {
     fluxFunction.ComputeViscousFlux(state1, dqdx, dqdy, dqdz, flux_mat);
@@ -37,8 +39,8 @@ void NoSlipIsothWallBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &s
     flux_mat.Mult(nor, fluxN);
 }
 
-
-void NoSlipIsothWallBdrFaceIntegrator::ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr, const IntegrationPoint &ip)
+void NoSlipIsothWallBdrFaceIntegrator::ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr,
+                                                                 const IntegrationPoint &ip)
 {
     if (!constant)
     {
@@ -47,20 +49,20 @@ void NoSlipIsothWallBdrFaceIntegrator::ComputeBdrFaceLiftingFlux(const Vector &s
 
         T = T_wall.Eval(Tr, ip);
         V_wall.Eval(V, Tr, ip);
-
-        v = 1.0 / (R_gas * T);
     }
-    fluxN(0) = state1(0);
-    fluxN(1) = V(0) * v;
+    Prandtl::PointStateView Se{state1.GetData()};
+    const real_t beta = Prandtl::Flow::isothermal_wall_beta(Se, T, gasModel);
+    fluxN(mass_eq) = gasModel.mass(Se);
+    fluxN(mom_eq) = V(0) * beta;
     if (dim > 1)
     {
-        fluxN(2) = V(1) * v;
+        fluxN(mom_eq+1) = V(1) * beta;
         if (dim > 2)
         {
-            fluxN(3) = V(2) * v;
+            fluxN(mom_eq+2) = V(2) * beta;
         }
     }
-    fluxN(num_equations - 1) = -v;
+    fluxN(en_eq) = -beta;
     fluxN -= state1;
 }
 

--- a/src/Integrators/BoundaryConditions/NoSlipIsothWallBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/NoSlipIsothWallBdrFaceIntegrator.hpp
@@ -15,16 +15,19 @@ private:
     Vector V;
     FunctionCoefficient T_wall;
     VectorFunctionCoefficient V_wall;
-
-    const real_t R_gas;
 public:
-    NoSlipIsothWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, real_t R_gas, FunctionCoefficient &T_wall, VectorFunctionCoefficient &V_wall, bool t_dependent = false);
-    NoSlipIsothWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, real_t R_gas, real_t &T, const Vector &V);
-    
+    NoSlipIsothWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                     const IdealGasModel &gasModel_,
+                                     const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                     FunctionCoefficient &T_wall, VectorFunctionCoefficient &V_wall, bool t_dependent = false);
+    NoSlipIsothWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                     const IdealGasModel &gasModel_,
+                                     const NumericalFlux &rsolver, const int Np, const real_t &time, real_t &T, const Vector &V);
     virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     virtual void ComputeBdrFaceLiftingFlux(const Vector &state1, Vector &fluxN, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
+
 };
 
 }

--- a/src/Integrators/BoundaryConditions/RiemannInvariantBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/RiemannInvariantBdrFaceIntegrator.cpp
@@ -1,41 +1,43 @@
 #include "RiemannInvariantBdrFaceIntegrator.hpp"
 #include "BasicOperations.hpp"
+#include "Flow.hpp"
 
 namespace Prandtl
 {
-// Constructor for RiemannInvariantBdrFaceIntegrator with a variable (space- and/or time-dependent) primitive state
-RiemannInvariantBdrFaceIntegrator::RiemannInvariantBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, VectorFunctionCoefficient &prim_state_fun, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
-    prim_state_fun(prim_state_fun), gammaInverse(1.0 / gamma)
-{
+  // Constructor for RiemannInvariantBdrFaceIntegrator with a variable (space- and/or time-dependent) primitive state
+  RiemannInvariantBdrFaceIntegrator::RiemannInvariantBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np,
+                                                                       const real_t &time,
+                                                                       VectorFunctionCoefficient &prim_state_fun, bool t_dependent)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
+    prim_state_fun(prim_state_fun)
+  {
     unit_nor.SetSize(dim);
-    V_o.SetSize(dim);
-    prim_state.SetSize(num_equations);
-}
-
-// Constructor for RiemannInvariantBdrFaceIntegrator with a constant primitive state
-RiemannInvariantBdrFaceIntegrator::RiemannInvariantBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, const Vector &prim_state)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, true, false),
-    prim_state_fun(num_equations, std::function<void(const Vector&, Vector&)>()), gammaInverse(1.0 / gamma)
-{
+    prim_o.SetSize(num_equations);
+    state_o.SetSize(num_equations);
+  }
+  
+  // Constructor for RiemannInvariantBdrFaceIntegrator with a constant primitive state
+  RiemannInvariantBdrFaceIntegrator::RiemannInvariantBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np,
+                                                                       const real_t &time, const Vector &prim_state)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false),
+    prim_state_fun(num_equations, std::function<void(const Vector&, Vector&)>())
+  {
     unit_nor.SetSize(dim);
-    V_o.SetSize(dim);
-
-    rho_o = prim_state(0);
-    p_o = prim_state(num_equations - 1);
-    V_o(0) = prim_state(1);
-    if (dim > 1)
-    {
-        V_o(1) = prim_state(2);
-        if (dim > 2)
-        {
-            V_o(2) = prim_state(3);
-        }
-    }
+    prim_o.SetSize(num_equations);
+    state_o.SetSize(num_equations);
+    prim_o(gasModel.L.eq_mass) = prim_state(gasModel.L.eq_mass);
+    prim_o(gasModel.L.eq_energy) = prim_state(gasModel.L.eq_energy);
+    size_t voff = gasModel.L.eq_mom[0];
+    prim_o(voff) = prim_state(voff);
+    if (dim > 1) prim_o(voff+1) = prim_state(voff+1);
+    if (dim > 2) prim_o(voff+2) = prim_state(voff+2);
+    Prandtl::PointPrimitiveView P{prim_o.GetData()};
+    Prandtl::PointStateViewRW S{state_o.GetData()};
+    Prandtl::Flow::PrimitiveToConserved(P, S, gasModel);
 }
 
 void RiemannInvariantBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip)
@@ -46,69 +48,19 @@ void RiemannInvariantBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &
     if (!constant)
     {
         if (t_dependent)
-        {
             prim_state_fun.SetTime(time);
-        }
-  
-        prim_state_fun.Eval(prim_state, Tr, ip);
-        rho_o = prim_state(0);
-        p_o = prim_state(num_equations - 1);
-        V_o(0) = prim_state(1);
-        if (dim > 1)
-        {
-            V_o(1) = prim_state(2);
-            if (dim > 2)
-            {
-                V_o(2) = prim_state(3);
-            }
-        }
+        
+        prim_state_fun.Eval(prim_o, Tr, ip);
+        Prandtl::PointPrimitiveView P{prim_o.GetData()};
+        Prandtl::PointStateViewRW S{state_o.GetData()};
+        Prandtl::Flow::PrimitiveToConserved(P, S, gasModel);
     }
+    Prandtl::PointStateView So{state_o.GetData()};
+    Prandtl::PointStateView Si{state1.GetData()};
+    Prandtl::PointStateViewRW S2{state2.GetData()};
+    real_t n[3] = { unit_nor(0), (dim>1 ? unit_nor(1) : 0.0), (dim>2 ? unit_nor(2) : 0.0) };
 
-    Vector V_i(dim);
-    for(int i = 0;i < dim;i++) V_i(i) = state1(i+1) / state1(0);
-    Vn_i = V_i * unit_nor;
-    Vn_o = V_o * unit_nor;
-
-    p_i = ComputePressure(state1, gammaM1);
-
-    a_o = ComputeSoundSpeed(p_o, rho_o, gamma);
-    a_i = ComputeSoundSpeed(p_i, state1(0), gamma);
-
-    R_minus = (std::abs(Vn_o) >= a_o && Vn_i >= 0.0) ? 
-               Vn_i - 2.0 * a_i * gammaM1Inverse : Vn_o - 2.0 * a_o * gammaM1Inverse;
-    R_plus =  (std::abs(Vn_o) >= a_o && Vn_i < 0.0) ? 
-               Vn_o + 2.0 * a_o * gammaM1Inverse : Vn_i + 2.0 * a_i * gammaM1Inverse;
-
-    Vn_b = 0.5 * (R_plus + R_minus);
-    a_b = 0.25 * gammaM1 * (R_plus - R_minus);
-    
-    dVn_i = Vn_b - Vn_i;
-    dVn_o = Vn_b - Vn_o;
-    
-    state2(0) = (Vn_i < 0.0) ?
-                 std::pow(a_b * a_b * gammaInverse * rho_o / p_o, gammaM1Inverse) * rho_o :
-                 std::pow(a_b * a_b * gammaInverse * state1(0) / p_i, gammaM1Inverse) * state1(0);
-    state2(1) = (Vn_i >= 0.0) ?
-                 state2(0) * (V_i(0) + dVn_i * unit_nor(0)) :
-                 state2(0) * (V_o(0) + dVn_o * unit_nor(0));
-    state2(num_equations - 1) = state2(1) * state2(1);
-    if (dim > 1)
-    {
-        state2(2) = (Vn_i >= 0.0) ?
-                    state2(0) * (V_i(1) + dVn_i * unit_nor(1)) :
-                    state2(0) * (V_o(1) + dVn_o * unit_nor(1));
-        state2(num_equations - 1) += state2(2) * state2(2);
-        if (dim > 2)
-        {
-            state2(3) = (Vn_i >= 0.0) ?
-                         state2(0) * (V_i(2) + dVn_i * unit_nor(2)) :
-                         state2(0) * (V_o(2) + dVn_o * unit_nor(2));
-            state2(num_equations - 1) += state2(3) * state2(3);
-        }
-    }
-    p_b = a_b * a_b * state2(0) * gammaInverse;
-    state2(num_equations - 1) *= (0.5 / state2(0));
-    state2(num_equations - 1) += p_b * gammaM1Inverse;
+    Prandtl::Flow::riemann_invariant_outer_state(Si, So, S2, n, gasModel);
 }
 
 void RiemannInvariantBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx_, const Vector &dqdy_, const Vector &dqdz_, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)

--- a/src/Integrators/BoundaryConditions/RiemannInvariantBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/RiemannInvariantBdrFaceIntegrator.hpp
@@ -10,20 +10,19 @@ using namespace mfem;
 class RiemannInvariantBdrFaceIntegrator : public BdrFaceIntegrator
 {
 private:
-    VectorFunctionCoefficient prim_state_fun;
-    Vector prim_state;
-    real_t rho_o, p_o, p_i, p_b, a_o, a_i, a_b;
-    Vector V_o;
-    real_t Vn_o, Vn_i, Vn_b, dVn_o, dVn_i;
-    Vector unit_nor;
-    real_t R_plus, R_minus; // Riemann Invariants
-
-    const real_t gammaInverse;
+  VectorFunctionCoefficient prim_state_fun;
+  Vector prim_o;
+  Vector state_o;
+  Vector unit_nor;
 
 public:
-    RiemannInvariantBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, VectorFunctionCoefficient &prim_state_fun, bool t_dependent = false);
-    RiemannInvariantBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, const Vector &prim_state);
-
+    RiemannInvariantBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                      const IdealGasModel &gasModel_,
+                                      const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                      VectorFunctionCoefficient &prim_state_fun, bool t_dependent = false);
+    RiemannInvariantBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                      const IdealGasModel &gasModel_,
+                                      const NumericalFlux &rsolver, const int Np, const real_t &time, const Vector &prim_state);
     virtual void ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     
     virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;

--- a/src/Integrators/BoundaryConditions/SlipWallBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SlipWallBdrFaceIntegrator.cpp
@@ -1,11 +1,15 @@
 #include "SlipWallBdrFaceIntegrator.hpp"
 #include "BasicOperations.hpp"
+#include "Flow.hpp"
 
 namespace Prandtl
 {
 
-SlipWallBdrFaceIntegrator::SlipWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, int Np, const real_t &time, real_t gamma, bool constant, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, constant, t_dependent), gammaP1(1.0 + gamma), gammaP1Inverse(1.0 / gammaP1)
+  SlipWallBdrFaceIntegrator::SlipWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                       const IdealGasModel &gasModel_,
+                                                       const NumericalFlux &rsolver, int Np, const real_t &time,
+                                                       bool constant, bool t_dependent)
+    : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, constant, t_dependent)
 {
     unit_nor.SetSize(rsolver.GetFluxFunction().dim);
     prim.SetSize(rsolver.GetFluxFunction().num_equations);
@@ -18,45 +22,19 @@ real_t SlipWallBdrFaceIntegrator::ComputeBdrFaceInviscidFlux(const Vector &state
     unit_nor = nor;
     Normalize(unit_nor);
     state2 = state1;
-    if (nor.Size() > 1)
-    {
-        RotateState(state2, unit_nor);
-    }
-    else
-    {
-        state2(1) = state2(1) * nor(0);
-    }
-
-    Conserv2Prim(state2, prim, gammaM1);
-
-    Vector vel(prim.GetData() + 1, nor.Size());
-    an = ComputeSoundSpeed(prim(prim.Size() - 1), prim(0), gamma);
-    if (prim(1) > 0.0)
-    {
-        p_star = prim(prim.Size() - 1) +
-            0.25 * prim(1) * gammaP1 * prim(0) *
-            (prim(1) + std::sqrt(std::pow(prim(1), 2) +
-            8.0 * gammaP1Inverse / prim(0) * prim(prim.Size() - 1) * (gammaM1 * gammaP1Inverse + 1.0)));
-    }
-    else
-    {
-        p_star = prim(prim.Size() - 1) *
-            std::pow(std::max(1.0 + 0.5 * gammaM1 * prim(1) /
-            an, 0.0001), 2.0 * gamma * gammaM1Inverse); 
-    }
-
+    RotateState(gasModel.L, state2, unit_nor);
+    Prandtl::PointStateView S{state2.GetData()};
+    const real_t p_star = Prandtl::Flow::slipwall_pstar(S, gasModel);
+    const real_t v = gasModel.velocity(S, 0);
+    const real_t c = gasModel.sound_speed(S);
     fluxN = 0.0;
-    fluxN(1) = p_star * nor(0);
-    if (nor.Size() > 1)
-    {
-        fluxN(2) = p_star * nor(1);
-        if (nor.Size() > 2)
-        {
-            fluxN(3) = p_star * nor(2);
-        }
+    fluxN(mom_eq) = p_star * nor(0);
+    if (dim > 1){
+      fluxN(mom_eq+1) = p_star * nor(1);
+      if (dim > 2)
+        fluxN(mom_eq+2) = p_star * nor(2);
     }
-
-    return std::sqrt(vel * vel) + an;
+    return std::abs(v) + c;
 }
 
 }

--- a/src/Integrators/BoundaryConditions/SlipWallBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SlipWallBdrFaceIntegrator.hpp
@@ -14,11 +14,11 @@ private:
     Vector unit_nor;
     Vector prim;
     real_t p_star, an;
-protected:
-    const real_t gammaP1, gammaP1Inverse;
 public:
-    SlipWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, int Np, const real_t &time, real_t gamma, bool constant = true, bool t_dependent = false);
-    virtual real_t ComputeBdrFaceInviscidFlux(const Vector &state1, Vector &state2, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
+  SlipWallBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const IdealGasModel &gasModel_,
+                            const NumericalFlux &rsolver, int Np, const real_t &time, bool constant = true, bool t_dependent = false);
+    virtual real_t ComputeBdrFaceInviscidFlux(const Vector &state1, Vector &state2, Vector &fluxN, const Vector &nor,
+                                              FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
 };
 
 

--- a/src/Integrators/BoundaryConditions/SpecifiedStateBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SpecifiedStateBdrFaceIntegrator.cpp
@@ -4,19 +4,22 @@ namespace Prandtl
 {
 
 // Constructor for SpecifiedStateBdrfaceIntegrator with a variable (space- and/or time-dependent) conservative state
-SpecifiedStateBdrFaceIntegrator::SpecifiedStateBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, VectorFunctionCoefficient &conserv_state_fun_, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
-    conserv_state_fun(conserv_state_fun_) {}
+SpecifiedStateBdrFaceIntegrator::SpecifiedStateBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                 const IdealGasModel &gasModel_,
+                                                                 const NumericalFlux &rsolver, const int Np,
+                                                                 const real_t &time,
+                                                                 VectorFunctionCoefficient &conserv_state_fun_, bool t_dependent)
+: BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
+  conserv_state_fun(conserv_state_fun_) {}
 
 
 // Constructor for SpecifiedStateBdrfaceIntegrator with a constant conservative state
-SpecifiedStateBdrFaceIntegrator::SpecifiedStateBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, int Np,
-    const real_t &time, real_t gamma, const Vector &conserv_state)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, true, false), 
-    const_state(conserv_state), conserv_state_fun(num_equations, std::function<void(const Vector&, Vector&)>()) {}
+SpecifiedStateBdrFaceIntegrator::SpecifiedStateBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                 const IdealGasModel &gasModel_,
+                                                                 const NumericalFlux &rsolver, int Np,
+                                                                 const real_t &time, const Vector &conserv_state)
+: BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false), 
+  const_state(conserv_state), conserv_state_fun(num_equations, std::function<void(const Vector&, Vector&)>()) {}
 
 void SpecifiedStateBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2,
     FaceElementTransformations &Tr, const IntegrationPoint &ip)

--- a/src/Integrators/BoundaryConditions/SpecifiedStateBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SpecifiedStateBdrFaceIntegrator.hpp
@@ -14,9 +14,13 @@ private:
     VectorFunctionCoefficient conserv_state_fun;
     Vector const_state;
 public:
-    SpecifiedStateBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, VectorFunctionCoefficient &conserv_state_fun, bool t_dependent = false);
-    SpecifiedStateBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, int Np, const real_t &time, real_t gamma, const Vector &conserv_state);
-    
+    SpecifiedStateBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                    const IdealGasModel &gasModel_,
+                                    const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                    VectorFunctionCoefficient &conserv_state_fun, bool t_dependent = false);
+    SpecifiedStateBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                    const IdealGasModel &gasModel_,
+                                    const NumericalFlux &rsolver, int Np, const real_t &time, const Vector &conserv_state);
     virtual void ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;

--- a/src/Integrators/BoundaryConditions/SubsonicInflowPtTtAngBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SubsonicInflowPtTtAngBdrFaceIntegrator.cpp
@@ -1,18 +1,21 @@
 #include "SubsonicInflowPtTtAngBdrFaceIntegrator.hpp"
 #include "BasicOperations.hpp"
+#include "Flow.hpp"
 
 namespace Prandtl
 {
 
-SubsonicInflowPtTtAngBdrFaceIntegrator::SubsonicInflowPtTtAngBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, real_t cp, FunctionCoefficient &pt, FunctionCoefficient &Tt, real_t theta, real_t phi, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
-    gammaM1_gammaInverse(gammaM1 / gamma), gamma_gammaM1Inverse(gamma * gammaM1Inverse), cp(cp),
-    pt(pt), Tt(Tt), theta(theta), phi(phi)
+SubsonicInflowPtTtAngBdrFaceIntegrator::SubsonicInflowPtTtAngBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                               const IdealGasModel &gasModel_,
+                                                                               const NumericalFlux &rsolver, const int Np,
+                                                                               const real_t &time,
+                                                                               FunctionCoefficient &pt, FunctionCoefficient &Tt,
+                                                                               real_t theta, real_t phi, bool t_dependent)
+: BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
+  pt(pt), Tt(Tt), theta(theta), phi(phi)
 {
-    V_comps.SetSize(dim);
-
+  V_comps.SetSize(dim);
+  
     if (dim > 1)
     {
         V_comps(0) = std::cos(theta * M_PI / 180.0);
@@ -26,13 +29,14 @@ SubsonicInflowPtTtAngBdrFaceIntegrator::SubsonicInflowPtTtAngBdrFaceIntegrator(
     }
 }
 
-SubsonicInflowPtTtAngBdrFaceIntegrator::SubsonicInflowPtTtAngBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, real_t cp, real_t pt, real_t Tt, real_t theta, real_t phi)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, true, false),
-    gammaM1_gammaInverse(gammaM1 / gamma), gamma_gammaM1Inverse(gamma * gammaM1Inverse), cp(cp),
-    p0(pt), T0(Tt), theta(theta), phi(phi),
-    pt(std::function<real_t(const Vector&)>()), Tt(std::function<real_t(const Vector&)>())
+SubsonicInflowPtTtAngBdrFaceIntegrator::SubsonicInflowPtTtAngBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                               const IdealGasModel &gasModel_,
+                                                                               const NumericalFlux &rsolver, const int Np,
+                                                                               const real_t &time, real_t pt,
+                                                                               real_t Tt, real_t theta, real_t phi)
+: BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false),
+  p0(pt), T0(Tt), theta(theta), phi(phi),
+  pt(std::function<real_t(const Vector&)>()), Tt(std::function<real_t(const Vector&)>())
 {
     V_comps.SetSize(dim);
 
@@ -61,22 +65,19 @@ void SubsonicInflowPtTtAngBdrFaceIntegrator::ComputeOuterInviscidState(const Vec
         p0 = pt.Eval(Tr, ip);
         T0 = Tt.Eval(Tr, ip);
     }
-
-    p = ComputePressure(state1, gammaM1);
-    V_sq = 2.0 * cp * T0 * (1.0 - std::pow(p / p0, gammaM1_gammaInverse));
-    V_sq = std::max(0.0, V_sq);
-
-    state2(0) = gamma_gammaM1Inverse * p / (cp * T0 - 0.5 * V_sq);
-    state2(1) = state2(0) * std::sqrt(V_sq) * V_comps(0);
+    Prandtl::PointStateView S1{state1.GetData()};
+    Prandtl::PointStateViewRW S2{state2.GetData()};
+    auto tot = Prandtl::Flow::isentropic_total_to_static(S1, {p0, T0}, gasModel);
+    S2.set_mass(gasModel.L, tot.rho);
+    const real_t v = std::sqrt(tot.v2);
+    S2.set_momentum(gasModel.L, 0, tot.rho*v*V_comps(0));
     if (dim > 1)
     {
-        state2(2) = state2(0) * std::sqrt(V_sq) * V_comps(1);
-        if (dim > 2)
-        {
-            state2(3) = state2(0) * std::sqrt(V_sq) * V_comps(2);
-        }
+      S2.set_momentum(gasModel.L, 1, tot.rho*v*V_comps(1));
+      if (dim > 2)
+        S2.set_momentum(gasModel.L, 2, tot.rho*v* V_comps(2));
     }
-    state2(num_equations - 1) = p * gammaM1Inverse + 0.5 * state2(0) * V_sq;
+    S2.set_energy(gasModel.L, tot.energy);
 }
 
 void SubsonicInflowPtTtAngBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)

--- a/src/Integrators/BoundaryConditions/SubsonicInflowPtTtAngBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SubsonicInflowPtTtAngBdrFaceIntegrator.hpp
@@ -7,20 +7,26 @@ namespace Prandtl
 
 using namespace mfem;
 
-class SubsonicInflowPtTtAngBdrFaceIntegrator : public BdrFaceIntegrator
-{
-private:
+  class SubsonicInflowPtTtAngBdrFaceIntegrator : public BdrFaceIntegrator
+  {
+  private:
     real_t p;
     real_t V_sq;
     real_t p0, T0;
     real_t theta, phi;
     Vector V_comps, pT;
     FunctionCoefficient pt, Tt;
-
-    const real_t gammaM1_gammaInverse, gamma_gammaM1Inverse, cp;
-public:
-    SubsonicInflowPtTtAngBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, real_t cp, FunctionCoefficient &pt, FunctionCoefficient &Tt, real_t theta = 0.0, real_t phi = 0.0, bool t_dependent = false);
-    SubsonicInflowPtTtAngBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, real_t cp, real_t pt, real_t Tt, real_t theta = 0.0, real_t phi = 0.0);
+    
+  public:
+    SubsonicInflowPtTtAngBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                           const IdealGasModel &gasModel_,
+                                           const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                           FunctionCoefficient &pt, FunctionCoefficient &Tt,
+                                           real_t theta = 0.0, real_t phi = 0.0, bool t_dependent = false);
+    SubsonicInflowPtTtAngBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                           const IdealGasModel &gasModel_,
+                                           const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                           real_t pt, real_t Tt, real_t theta = 0.0, real_t phi = 0.0);
 
     virtual void ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     

--- a/src/Integrators/BoundaryConditions/SubsonicInflowRVBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SubsonicInflowRVBdrFaceIntegrator.cpp
@@ -3,19 +3,28 @@
 namespace Prandtl
 {
 
-SubsonicInflowRVBdrFaceIntegrator::SubsonicInflowRVBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, FunctionCoefficient &rho_, VectorFunctionCoefficient &V_, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
+  SubsonicInflowRVBdrFaceIntegrator::SubsonicInflowRVBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np,
+                                                                       const real_t &time, FunctionCoefficient &rho_,
+                                                                       VectorFunctionCoefficient &V_, bool t_dependent)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
     rho(rho_), V(V_) {}
-
-SubsonicInflowRVBdrFaceIntegrator::SubsonicInflowRVBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, real_t rho, const Vector &V)
-    : BdrFaceIntegrator(liftingScheme,rsolver, Np, time, gamma, true, false),
-    r(rho), u(V), rho(std::function<real_t(const Vector&)>()), V(dim, std::function<void(const Vector&, Vector&)>()) {}
-
-void SubsonicInflowRVBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip)
+  
+  SubsonicInflowRVBdrFaceIntegrator::SubsonicInflowRVBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np,
+                                                                       const real_t &time, real_t rho, const Vector &V)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false),
+    r(rho), u(V), rho(std::function<real_t(const Vector&)>()), V(dim, std::function<void(const Vector&, Vector&)>())
+  {
+    u2 = 0.0;
+    for (int idim = 0;idim < dim;idim++){
+      u2 += u(idim)*u(idim);
+    }
+  }
+  
+  void SubsonicInflowRVBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {
     if (!constant)
     {
@@ -26,25 +35,19 @@ void SubsonicInflowRVBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &
         }
         r = rho.Eval(Tr, ip);
         V.Eval(u, Tr, ip);
+        u2 = u(0)*u(0);
+        if (dim > 1) u2 += u(1)*u(1);
+        if (dim > 2) u2 += u(2)*u(2);
     }
-
-    state2(0) = r;
-    state2(1) = r * u(0);
-    dke = -state1(1) * state1(1);
-    state2(num_equations - 1) = state1(num_equations - 1);
-    if (dim > 1)
-    {
-        state2(2) = r * u(1);
-        dke -= state1(2) * state1(2);
-        if (dim > 2)
-        {
-            state2(3) = r * u(2);
-            dke -= state1(3) * state1(3);
-        }
-    }
-    dke *= 0.5 / state1(0);
-    dke += 0.5 * (u * u) * r;
-    state2(num_equations - 1) += dke;
+    Prandtl::PointStateView S1{state1.GetData()};
+    Prandtl::PointStateViewRW S2{state2.GetData()};
+    S2.set_mass(gasModel.L, r);
+    S2.set_momentum(gasModel.L, 0, r * u(0));
+    if (dim > 1) S2.set_momentum(gasModel.L, 1, r*u(1));
+    if (dim > 2) S2.set_momentum(gasModel.L, 2, r*u(2));
+    const real_t ke1 = gasModel.kinetic_energy_density(S1);
+    const real_t ke2 = 0.5 * u2 * r;
+    S2.set_energy(gasModel.L, S1.energy(gasModel.L)+ke2-ke1);
 }
 
 void SubsonicInflowRVBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx_, const Vector &dqdy_, const Vector &dqdz_, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)

--- a/src/Integrators/BoundaryConditions/SubsonicInflowRVBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SubsonicInflowRVBdrFaceIntegrator.hpp
@@ -10,14 +10,20 @@ using namespace mfem;
 class SubsonicInflowRVBdrFaceIntegrator : public BdrFaceIntegrator
 {
 private:
-    real_t dke;
+    real_t u2;
     real_t r;
     Vector u;
     FunctionCoefficient rho;
     VectorFunctionCoefficient V;
 public:
-    SubsonicInflowRVBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, FunctionCoefficient &rho, VectorFunctionCoefficient &V, bool t_dependent = false);
-    SubsonicInflowRVBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, real_t rho, const Vector &V);
+    SubsonicInflowRVBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                      const IdealGasModel &gasModel_,
+                                      const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                      FunctionCoefficient &rho, VectorFunctionCoefficient &V, bool t_dependent = false);
+    SubsonicInflowRVBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                      const IdealGasModel &gasModel_,
+                                      const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                      real_t rho, const Vector &V);
     
     virtual void ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
 

--- a/src/Integrators/BoundaryConditions/SubsonicOutflowPBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SubsonicOutflowPBdrFaceIntegrator.cpp
@@ -3,16 +3,20 @@
 namespace Prandtl
 {
 
-SubsonicOutflowPBdrFaceIntegrator::SubsonicOutflowPBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, FunctionCoefficient &p_fun, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
+  SubsonicOutflowPBdrFaceIntegrator::SubsonicOutflowPBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                                                       FunctionCoefficient &p_fun, bool t_dependent)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
     p_fun(p_fun) {}
-
-SubsonicOutflowPBdrFaceIntegrator::SubsonicOutflowPBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, real_t p)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, true, false),
+  
+  SubsonicOutflowPBdrFaceIntegrator::SubsonicOutflowPBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np,
+                                                                       const real_t &time, real_t p)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false),
     p(p), p_fun(std::function<real_t(const Vector&)>()) {}
-
+  
 
 void SubsonicOutflowPBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {
@@ -24,10 +28,13 @@ void SubsonicOutflowPBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &
         }
         p = p_fun.Eval(Tr, ip);
     }
-    Vector vel(dim);
-    for(int i = 0;i < dim;i++) vel(i) = state1(i+1) / state1(0);
+
     state2 = state1;
-    state2(num_equations - 1) = p * gammaM1Inverse + 0.5 * state1(0) * (vel * vel);
+    Prandtl::PointStateView S1{state1.GetData()};
+    Prandtl::PointStateViewRW S2{state2.GetData()};
+    const real_t ke1 = gasModel.kinetic_energy_density(S1);
+    const real_t ie = gasModel.internal_energy_from_pressure(S1, p);
+    S2.set_energy(gasModel.L, ie + ke1);
 }
 
 void SubsonicOutflowPBdrFaceIntegrator::ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx_, const Vector &dqdy_, const Vector &dqdz_, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)

--- a/src/Integrators/BoundaryConditions/SubsonicOutflowPBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SubsonicOutflowPBdrFaceIntegrator.hpp
@@ -14,8 +14,13 @@ private:
     real_t V_sq;
     FunctionCoefficient p_fun;
 public:
-    SubsonicOutflowPBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, FunctionCoefficient &p_fun, bool t_dependent = false);
-    SubsonicOutflowPBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, real_t p_out);
+  SubsonicOutflowPBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                    const IdealGasModel &gasModel_,
+                                    const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                    FunctionCoefficient &p_fun, bool t_dependent = false);
+    SubsonicOutflowPBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                      const IdealGasModel &gasModel_,
+                                      const NumericalFlux &rsolver, const int Np, const real_t &time, real_t p_out);
     
     virtual void ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
 

--- a/src/Integrators/BoundaryConditions/SupersonicInflowBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SupersonicInflowBdrFaceIntegrator.cpp
@@ -3,21 +3,24 @@
 namespace Prandtl
 {
 
-// Constructor for SupersonicInflowBdrFaceIntegrator with a variable (space- and/or time-dependent) conservative state
-SupersonicInflowBdrFaceIntegrator::SupersonicInflowBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, VectorFunctionCoefficient &conserv_state_fun, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, false, t_dependent),
+  // Constructor for SupersonicInflowBdrFaceIntegrator with a variable (space- and/or time-dependent) conservative state
+  SupersonicInflowBdrFaceIntegrator::SupersonicInflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np,
+                                                                       const real_t &time,
+                                                                       VectorFunctionCoefficient &conserv_state_fun, bool t_dependent)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, false, t_dependent),
     conserv_state_fun(conserv_state_fun) {}
-
-// Constructor for SupersonicInflowBdrFaceIntegrator with a constant (space- and/or time-dependent) conservative state
-SupersonicInflowBdrFaceIntegrator::SupersonicInflowBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np,
-    const real_t &time, real_t gamma, const Vector &conserv_state)
-    : BdrFaceIntegrator(liftingScheme,rsolver, Np, time, gamma, true, false),
+  
+  // Constructor for SupersonicInflowBdrFaceIntegrator with a constant (space- and/or time-dependent) conservative state
+  SupersonicInflowBdrFaceIntegrator::SupersonicInflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                       const IdealGasModel &gasModel_,
+                                                                       const NumericalFlux &rsolver, const int Np,
+                                                                       const real_t &time, const Vector &conserv_state)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false),
     const_state(conserv_state), conserv_state_fun(num_equations, std::function<void(const Vector&, Vector&)>())
-{
-}
+  {
+  }
 
 void SupersonicInflowBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {

--- a/src/Integrators/BoundaryConditions/SupersonicInflowBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SupersonicInflowBdrFaceIntegrator.hpp
@@ -12,8 +12,14 @@ private:
     Vector const_state;
     VectorFunctionCoefficient conserv_state_fun;
 public:
-    SupersonicInflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, VectorFunctionCoefficient &conserv_state_fun, bool t_dependent = false);
-    SupersonicInflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma, const Vector &conserv_state);
+    SupersonicInflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                      const IdealGasModel &gasModel_,
+                                      const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                      VectorFunctionCoefficient &conserv_state_fun, bool t_dependent = false);
+    SupersonicInflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                      const IdealGasModel &gasModel_,
+                                      const NumericalFlux &rsolver, const int Np, const real_t &time,
+                                      const Vector &conserv_state);
     
     virtual void ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
 

--- a/src/Integrators/BoundaryConditions/SupersonicOutflowBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SupersonicOutflowBdrFaceIntegrator.cpp
@@ -3,9 +3,11 @@
 namespace Prandtl
 {
 
-SupersonicOutflowBdrFaceIntegrator::SupersonicOutflowBdrFaceIntegrator(
-    std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, true, false) {}
+  SupersonicOutflowBdrFaceIntegrator::SupersonicOutflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                                         const IdealGasModel &gasModel_,
+                                                                         const NumericalFlux &rsolver, const int Np,
+                                                                         const real_t &time)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, true, false) {}
 
 void SupersonicOutflowBdrFaceIntegrator::ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip)
 {

--- a/src/Integrators/BoundaryConditions/SupersonicOutflowBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SupersonicOutflowBdrFaceIntegrator.hpp
@@ -9,8 +9,9 @@ using namespace mfem;
 class SupersonicOutflowBdrFaceIntegrator : public BdrFaceIntegrator
 {
 public:
-    SupersonicOutflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, const int Np, const real_t &time, real_t gamma);
-    
+    SupersonicOutflowBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                       const IdealGasModel &gasModel_,
+                                       const NumericalFlux &rsolver, const int Np, const real_t &time);
     virtual void ComputeOuterInviscidState(const Vector &state1, Vector &state2, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
     
     virtual void ComputeBdrFaceViscousFlux(const Vector &state1, const Vector &state2, const Vector &dqdx, const Vector &dqdy, const Vector &dqdz, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;

--- a/src/Integrators/BoundaryConditions/SymmetryBdrFaceIntegrator.cpp
+++ b/src/Integrators/BoundaryConditions/SymmetryBdrFaceIntegrator.cpp
@@ -4,9 +4,12 @@
 namespace Prandtl
 {
 
-SymmetryBdrFaceIntegrator::SymmetryBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, int Np, const real_t &time, real_t gamma, bool constant, bool t_dependent)
-    : BdrFaceIntegrator(liftingScheme, rsolver, Np, time, gamma, constant, t_dependent) { }
-
+  SymmetryBdrFaceIntegrator::SymmetryBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                                                       const IdealGasModel &gasModel_,
+                                                       const NumericalFlux &rsolver, int Np, const real_t &time,
+                                                       bool constant, bool t_dependent)
+  : BdrFaceIntegrator(liftingScheme, gasModel_, rsolver, Np, time, constant, t_dependent) { }
+  
 
 real_t SymmetryBdrFaceIntegrator::ComputeBdrFaceInviscidFlux(const Vector &state1, Vector &state2,
     Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip)
@@ -23,7 +26,7 @@ real_t SymmetryBdrFaceIntegrator::ComputeBdrFaceInviscidFlux(const Vector &state
 
     state2 = state1;
 
-    Vector mom(state2.GetData() + 1, unit_nor.Size());
+    Vector mom(state2.GetData() + gasModel.L.eq_mom[0], unit_nor.Size());
     const real_t mn = mom * unit_nor;
     mom.Add(-2.0 * mn, unit_nor);
 

--- a/src/Integrators/BoundaryConditions/SymmetryBdrFaceIntegrator.hpp
+++ b/src/Integrators/BoundaryConditions/SymmetryBdrFaceIntegrator.hpp
@@ -14,7 +14,10 @@ private:
     Vector unit_nor;
     Vector prim;
 public:
-    SymmetryBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme, const NumericalFlux &rsolver, int Np, const real_t &time, real_t gamma, bool constant = true, bool t_dependent = false);
+    SymmetryBdrFaceIntegrator(std::shared_ptr<LiftingScheme> liftingScheme,
+                              const IdealGasModel &gasModel_,
+                              const NumericalFlux &rsolver, int Np, const real_t &time,
+                              bool constant = true, bool t_dependent = false);
     virtual real_t ComputeBdrFaceInviscidFlux(const Vector &state1, Vector &state2, Vector &fluxN, const Vector &nor, FaceElementTransformations &Tr, const IntegrationPoint &ip) override;
 };
 

--- a/src/Integrators/DGSEMIntegrator/DGSEMIntegrator.cpp
+++ b/src/Integrators/DGSEMIntegrator/DGSEMIntegrator.cpp
@@ -3,19 +3,19 @@
 
 namespace Prandtl
 {
-bool debug_integrator = false;
+constexpr bool debug_integrator = false;
 
 DGSEMIntegrator::DGSEMIntegrator(
       std::shared_ptr<ParMesh> pmesh_,
       std::shared_ptr<ParFiniteElementSpace> fes0_,
       std::shared_ptr<ParGridFunction> alpha_,
       std::shared_ptr<LiftingScheme> liftingScheme_,
-      NumericalFlux &rsolver_, int Np, real_t gamma)
-    : NonlinearFormIntegrator(), pmesh(pmesh_), fes0(fes0_), alpha(alpha_), liftingScheme(liftingScheme_),
-      rsolver(rsolver_), fluxFunction(rsolver_.GetFluxFunction()),
+      NumericalFlux &rsolver_, int Np)
+    : NonlinearFormIntegrator(), pmesh(pmesh_), fes0(fes0_), alpha(alpha_),
+      liftingScheme(liftingScheme_), rsolver(rsolver_), fluxFunction(rsolver_.GetFluxFunction()),
       Np_x(Np), Np_y(fluxFunction.dim > 1 ? Np : 1), Np_z(fluxFunction.dim > 2 ? Np : 1),
-      num_equations(fluxFunction.num_equations), dim(num_equations - 2), num_elements(pmesh->GetNE()),
-      GLIntRules(0, Quadrature1D::GaussLobatto), gammaM1(gamma - 1.0)
+      num_equations(fluxFunction.num_equations), dim(fluxFunction.dim), num_elements(pmesh->GetNE()),
+      GLIntRules(0, Quadrature1D::GaussLobatto)
 {
     IntegrationOrder = 2 * Np_x - 3;
 
@@ -408,22 +408,24 @@ void DGSEMIntegrator::AssembleElementVector(const FiniteElement &el,
                     std::cout << "________________________________________________________________________________________________________________" << "\n";
                 }
 
+                // TODO: Axisym source term is misplaced here. Need source term constructs
+                //       to fix. It is a code smell that this bit of physics is leaking out to
+                //       this level.  Currently, we are forced to make a utility in NS object
+                //       to fetch the pressure to code around this breakage of the abstraction.
 #ifdef AXISYMMETRIC
                 
                 {
-                    
-                    const real_t p = PressureFromConservative(state1);
-                    //dU_inviscid(2) += p;
-                    el_dudt_mat(id1, 2) += p;
- 
-                if (debug_integrator)
-                {
-                    const DenseMatrix &Jm = Tr.Jacobian();
-                    const real_t dr_deta_dbg = (Jm.NumRows() > 1 && Jm.NumCols() > 1) ? Jm(1,1) : 0.0;
-                    std::cout << "[AssembleElement]" << " p = " << p << "\n"; //", r = " << r_hat << ", dr/deta = " << dr_deta_dbg << "\n";
-                    std::cout << "[AssembleElement]" << " rdU_inviscid[2]-pJ      = [" << dU_inviscid[0] << ", " << dU_inviscid[1] << ", " << dU_inviscid[2] << ", " << dU_inviscid[3] << "]\n";
-                }
-                    
+                  const real_t p = fluxFunction.pressure(state1.GetData());
+                  el_dudt_mat(id1, 2) += p;
+                  
+                  if (debug_integrator)
+                    {
+                      const DenseMatrix &Jm = Tr.Jacobian();
+                      const real_t dr_deta_dbg = (Jm.NumRows() > 1 && Jm.NumCols() > 1) ? Jm(1,1) : 0.0;
+                      std::cout << "[AssembleElement]" << " p = " << p << "\n"; //", r = " << r_hat << ", dr/deta = " << dr_deta_dbg << "\n";
+                      std::cout << "[AssembleElement]" << " rdU_inviscid[2]-pJ      = [" << dU_inviscid[0] << ", " << dU_inviscid[1] << ", " << dU_inviscid[2] << ", " << dU_inviscid[3] << "]\n";
+                    }
+                  
                 }            
 #endif
                 AddRow(el_dudt_mat, dU_inviscid, id1);
@@ -1302,18 +1304,5 @@ void DGSEMIntegrator::ComputeSubcellMetrics()
         }
     }   
 }
-
-#ifdef AXISYMMETRIC
-inline real_t DGSEMIntegrator::PressureFromConservative(const Vector& U) const
-{
-    const real_t rho = U(0);
-    const real_t mz  = U(1);
-    const real_t mr  = U(2);
-    const real_t E   = U(3);
-    const real_t ke = 0.5 * ((mz*mz + mr*mr) / rho);
-    return gammaM1 * (E - ke);
-}
-#endif
-
 
 }

--- a/src/Integrators/DGSEMIntegrator/DGSEMIntegrator.hpp
+++ b/src/Integrators/DGSEMIntegrator/DGSEMIntegrator.hpp
@@ -12,23 +12,22 @@ using namespace mfem;
 class DGSEMIntegrator : public NonlinearFormIntegrator
 {
 private:
-    std::shared_ptr<ParMesh> pmesh;
-    std::shared_ptr<ParFiniteElementSpace> fes0;
-    std::shared_ptr<ParGridFunction> alpha;
-    NumericalFlux &rsolver;
-    const NavierStokesFlux &fluxFunction;
-    DenseMatrix D_T, Dhat_T, Dhat2_T;
-    const int Np_x, Np_y, Np_z;
-    const int num_equations, dim, num_elements;
-    IntegrationRules GLIntRules;
-    const IntegrationRule *ir, *ir_face, *ir_vol;
+  std::shared_ptr<ParMesh> pmesh;
+  std::shared_ptr<ParFiniteElementSpace> fes0;
+  std::shared_ptr<ParGridFunction> alpha;
+  NumericalFlux &rsolver;
+  const NavierStokesFlux &fluxFunction;
+  DenseMatrix D_T, Dhat_T, Dhat2_T;
+  const int Np_x, Np_y, Np_z;
+  const int num_equations, dim, num_elements;
+  IntegrationRules GLIntRules;
+  const IntegrationRule *ir, *ir_face, *ir_vol;
 
     real_t max_char_speed;
     real_t J, J1, J2;
     int dof, dof1, dof2;
     int id1, id2;
     int IntegrationOrder;
-    real_t gammaM1;
 
     Vector shape1, shape2;
     Vector state1, state2;
@@ -76,7 +75,7 @@ public:
                     std::shared_ptr<ParFiniteElementSpace> fes0,
                     std::shared_ptr<ParGridFunction> alpha,
                     std::shared_ptr<LiftingScheme> liftingScheme,
-                    NumericalFlux &rsolver, int Np, real_t gamma);
+                    NumericalFlux &rsolver, int Np);
 
     void AssembleFaceVector(const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &Tr, const Vector &el_u, Vector &el_dudt) override;
     void AssembleElementVector(const FiniteElement &el, ElementTransformation &Tr, const Vector &el_u, Vector &el_dutdt) override;

--- a/src/Operators/DGSEMOperator.cpp
+++ b/src/Operators/DGSEMOperator.cpp
@@ -7,23 +7,21 @@ DGSEMOperator::DGSEMOperator(std::shared_ptr<ParFiniteElementSpace> vfes_,
                              std::shared_ptr<ParMesh> pmesh_,
                              std::shared_ptr<ParGridFunction> eta_,
                              std::shared_ptr<ParGridFunction> alpha_,
-                             std::shared_ptr<ParGridFunction> dudx_,
-                             std::shared_ptr<ParGridFunction> dudy_,
-                             std::shared_ptr<ParGridFunction> dudz_,
+                             std::vector<std::shared_ptr<ParGridFunction> > &grad_u_,
                              std::unique_ptr<DGSEMIntegrator> integrator_,
                              std::unique_ptr<Indicator> indicator_,
-                             const real_t gamma_,
+                             const IdealGasModel &gasModel_,
                              std::shared_ptr<ParGridFunction> r_gf_,
                              const real_t alpha_max, const real_t alpha_min)
                              : TimeDependentOperator(vfes_->GetTrueVSize()),
                              vfes(vfes_), fes0(fes0_), pmesh(pmesh_),
-                             eta(eta_), alpha(alpha_), dudx(dudx_), dudy(dudy_), dudz(dudz_),
+                               eta(eta_), alpha(alpha_), grad_u(grad_u_),
                              integrator(std::move(integrator_)), indicator(std::move(indicator_)),
+                             gasModel(gasModel_),
                              num_equations(vfes->GetVDim()), dim(pmesh->SpaceDimension()),
                              order(vfes->GetElementOrder(0)), num_elements(pmesh->GetNE()),
                              Ndofs(vfes->GetFE(0)->GetDof()),
                              modalThreshold(0.5 * std::pow(10.0, -1.8 * std::pow(order, 0.25))),
-                             gamma(gamma_), gammaM1(gamma - 1.0), gammaM1Inverse(1.0 / gammaM1),
                              r_gf(r_gf_), alpha_max(alpha_max), alpha_min(alpha_min),
                              num_dofs_scalar(vfes_->GetTrueVSize()/vfes_->GetVDim())
                              #ifdef AXISYMMETRIC
@@ -88,7 +86,7 @@ void DGSEMOperator::ComputeGlobalEntropyVector(const Vector &u, Vector &global_e
         vfes->GetElementVDofs(el, vdof_indices);
         u.GetSubVector(vdof_indices, el_vdofs);
         DenseMatrix vdof_mat(el_vdofs.GetData(), Ndofs, num_equations);
-        Conserv2Entropy(vdof_mat, ent_mat, gamma, gammaM1, gammaM1Inverse);
+        Conserv2Entropy(gasModel, vdof_mat, ent_mat);
         global_entropy.SetSubVector(vdof_indices, ent_mat.GetData());
     }
 }
@@ -104,7 +102,7 @@ void DGSEMOperator::ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &du
 
         dudx.GetSubVector(vdof_indices, grad_vdofs);
         DenseMatrix grad_mat(grad_vdofs.GetData(), Ndofs, num_equations);
-        EntropyGrad2PrimGrad(vdof_mat, grad_mat, gammaM1, gammaM1Inverse);
+        EntropyGrad2PrimGrad(gasModel, vdof_mat, grad_mat);
         dudx.SetSubVector(vdof_indices, grad_mat.GetData());
     }
 }
@@ -120,12 +118,12 @@ void DGSEMOperator::ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &du
 
         dudx.GetSubVector(vdof_indices, grad_vdofs);
         DenseMatrix grad_mat1(grad_vdofs.GetData(), Ndofs, num_equations);
-        EntropyGrad2PrimGrad(vdof_mat, grad_mat1, gammaM1, gammaM1Inverse);
+        EntropyGrad2PrimGrad(gasModel, vdof_mat, grad_mat1);
         dudx.SetSubVector(vdof_indices, grad_mat1.GetData());
 
         dudy.GetSubVector(vdof_indices, grad_vdofs);
         DenseMatrix grad_mat2(grad_vdofs.GetData(), Ndofs, num_equations);
-        EntropyGrad2PrimGrad(vdof_mat, grad_mat2, gammaM1, gammaM1Inverse);
+        EntropyGrad2PrimGrad(gasModel, vdof_mat, grad_mat2);
         dudy.SetSubVector(vdof_indices, grad_mat2.GetData());    
         
     }
@@ -142,19 +140,18 @@ void DGSEMOperator::ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &du
 
         dudx.GetSubVector(vdof_indices, grad_vdofs);
         DenseMatrix grad_mat1(grad_vdofs.GetData(), Ndofs, num_equations);
-        EntropyGrad2PrimGrad(vdof_mat, grad_mat1, gammaM1, gammaM1Inverse);
+        EntropyGrad2PrimGrad(gasModel, vdof_mat, grad_mat1);
         dudx.SetSubVector(vdof_indices, grad_mat1.GetData());
 
         dudy.GetSubVector(vdof_indices, grad_vdofs);
         DenseMatrix grad_mat2(grad_vdofs.GetData(), Ndofs, num_equations);
-        EntropyGrad2PrimGrad(vdof_mat, grad_mat2, gammaM1, gammaM1Inverse);
+        EntropyGrad2PrimGrad(gasModel, vdof_mat, grad_mat2);
         dudy.SetSubVector(vdof_indices, grad_mat2.GetData());
 
         dudz.GetSubVector(vdof_indices, grad_vdofs);
         DenseMatrix grad_mat3(grad_vdofs.GetData(), Ndofs, num_equations);
-        EntropyGrad2PrimGrad(vdof_mat, grad_mat3, gammaM1, gammaM1Inverse);
+        EntropyGrad2PrimGrad(gasModel, vdof_mat, grad_mat3);
         dudz.SetSubVector(vdof_indices, grad_mat3.GetData());      
-    
     }
 }
 
@@ -550,24 +547,24 @@ void DGSEMOperator::Mult(const Vector &u, Vector &dudt) const
       
 #ifdef PARABOLIC
     ComputeGlobalEntropyVector(Ustate, global_entropy);
-    
+
     if (dim == 1)
     {
-        nonlinearForm->MultLifting(global_entropy, *dudx);
-        ComputeGlobalPrimitiveGradVector(Ustate, *dudx);
-        nonlinearForm->Mult(Ustate, *dudx, dudt);
+        nonlinearForm->MultLifting(global_entropy, *grad_u[0]);
+        ComputeGlobalPrimitiveGradVector(Ustate, *grad_u[0]);
+        nonlinearForm->Mult(Ustate, *grad_u[0], dudt);
     }
     else if (dim == 2)
     {
-        nonlinearForm->MultLifting(global_entropy, *dudx, *dudy);
-        ComputeGlobalPrimitiveGradVector(Ustate, *dudx, *dudy);
-        nonlinearForm->Mult(Ustate, *dudx, *dudy, dudt);    
+      nonlinearForm->MultLifting(global_entropy, *grad_u[0], *grad_u[1]);
+      ComputeGlobalPrimitiveGradVector(Ustate, *grad_u[0], *grad_u[1]);
+      nonlinearForm->Mult(Ustate, *grad_u[0], *grad_u[1], dudt);    
     }
     else
     {
-        nonlinearForm->MultLifting(global_entropy, *dudx, *dudy, *dudz);
-        ComputeGlobalPrimitiveGradVector(Ustate, *dudx, *dudy, *dudz);
-        nonlinearForm->Mult(Ustate, *dudx, *dudy, *dudz, dudt);
+        nonlinearForm->MultLifting(global_entropy, *grad_u[0], *grad_u[1], *grad_u[2]);
+        ComputeGlobalPrimitiveGradVector(Ustate, *grad_u[0], *grad_u[1], *grad_u[2]);
+        nonlinearForm->Mult(Ustate, *grad_u[0], *grad_u[1], *grad_u[2], dudt);
     }
 
     #ifdef AXISYMMETRIC

--- a/src/Operators/DGSEMOperator.hpp
+++ b/src/Operators/DGSEMOperator.hpp
@@ -22,7 +22,6 @@ private:
     std::shared_ptr<ParGridFunction> eta;
     std::shared_ptr<ParGridFunction> alpha;
     std::vector<std::shared_ptr<ParGridFunction> > grad_u;
-    std::shared_ptr<ParGridFunction> dudx, dudy, dudz;
     std::shared_ptr<ParGridFunction> r_gf;
     std::unique_ptr<DGSEMIntegrator> integrator;
     std::unique_ptr<Indicator> indicator;

--- a/src/Operators/DGSEMOperator.hpp
+++ b/src/Operators/DGSEMOperator.hpp
@@ -6,6 +6,7 @@
 #include "ModalBasis.hpp"
 #include "Indicator.hpp"
 #include "BasicOperations.hpp"
+#include "GasModel.hpp"
 
 namespace Prandtl
 {
@@ -20,11 +21,13 @@ private:
     std::shared_ptr<ParMesh> pmesh;
     std::shared_ptr<ParGridFunction> eta;
     std::shared_ptr<ParGridFunction> alpha;
+    std::vector<std::shared_ptr<ParGridFunction> > grad_u;
     std::shared_ptr<ParGridFunction> dudx, dudy, dudz;
     std::shared_ptr<ParGridFunction> r_gf;
     std::unique_ptr<DGSEMIntegrator> integrator;
     std::unique_ptr<Indicator> indicator;
-    std::unique_ptr<DGSEMNonlinearForm> nonlinearForm;
+    const IdealGasModel gasModel;
+    std::unique_ptr<DGSEMNonlinearForm> nonlinearForm; 
 
     mutable Array<int> vdof_indices;
     mutable Vector el_vdofs, grad_vdofs;
@@ -60,10 +63,6 @@ private:
     mutable Vector ind_dof;
     mutable real_t alpha_dof;
 
-    const real_t gamma;
-    const real_t gammaM1;
-    const real_t gammaM1Inverse;
-    
     void ComputeGlobalEntropyVector(const Vector &u, Vector &global_entropy) const;
     void ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &dudx) const;
     void ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &dudx, Vector &dudy) const;
@@ -89,12 +88,10 @@ public:
                   std::shared_ptr<ParMesh> pmesh,
                   std::shared_ptr<ParGridFunction> eta,
                   std::shared_ptr<ParGridFunction> alpha,
-                  std::shared_ptr<ParGridFunction> dudx,
-                  std::shared_ptr<ParGridFunction> dudy,
-                  std::shared_ptr<ParGridFunction> dudz,
+                  std::vector<std::shared_ptr<ParGridFunction> > &grad_u_,
                   std::unique_ptr<DGSEMIntegrator> integrator,
                   std::unique_ptr<Indicator> indicator,
-                  real_t gamma,
+                  const IdealGasModel &gasModel_,
                   std::shared_ptr<ParGridFunction> r_gf = nullptr,
                   const real_t alpha_max = 0.5, const real_t alpha_min = 0.001);
     

--- a/src/RiemannSolvers/ChandrashekarFlux.cpp
+++ b/src/RiemannSolvers/ChandrashekarFlux.cpp
@@ -5,79 +5,73 @@
 namespace Prandtl
 {
 
-ChandrashekarFlux::ChandrashekarFlux(const NavierStokesFlux &fluxFunction, real_t gamma_)
-    : NumericalFlux(fluxFunction), metric(dim), mom(dim), gamma(gamma_), gammaM1(gamma - 1.0), gammaM1Inverse(1.0 / gammaM1) {}
-
+  ChandrashekarFlux::ChandrashekarFlux(const NavierStokesFlux &fluxFunction, const IdealGasModel &gasModel_)
+    : NumericalFlux(fluxFunction), gasModel(gasModel_)
+  {
+    metric.SetSize(dim);
+  }
+  
 real_t ChandrashekarFlux::ComputeVolumeFlux(const Vector &state1, const Vector &state2,
                                             const Vector &metric1, const Vector &metric2,
                                             Vector &F_tilde)
 {
     ComputeMean(metric1, metric2, metric);
-
-    rho1 = state1(0);
-    rho2 = state2(0);
-    rho_ln = ComputeLogMean(rho1, rho2);
-    drho = rho2 - rho1;
-
-    u1 = state1(1) / rho1;
-    u2 = state2(1) / rho2;
-    u_mean = 0.5 * (u1 + u2);
-    du = u2 - u1;
-    V_sq1 = u1 * u1;
-    V_sq2 = u2 * u2;
-    Vn = u_mean * metric(0);
-    mom(0) = rho_ln * u_mean;
-    h_hat = -0.25 * (u1 * u1 + u2 * u2) + u_mean * u_mean;
-
-    if (dim > 1)
-    {
-        v1 = state1(2) / rho1;
-        v2 = state2(2) / rho2;
-        v_mean = 0.5 * (v1 + v2);
-        dv = v2 - v1;
-        V_sq1 += v1 * v1;
-        V_sq2 += v2 * v2;
-        Vn += v_mean * metric(1);
-        mom(1) = rho_ln * v_mean;
-        h_hat += -0.25 * (v1 * v1 + v2 * v2) + v_mean * v_mean;
-
-        if (dim > 2)
-        {
-            w1 = state1(3) / rho1;
-            w2 = state2(3) / rho2;
-            w_mean = 0.5 * (w1 + w2);
-            dw = w2 - w1;
-            V_sq1 += w1 * w1;
-            V_sq2 += w2 * w2;
-            Vn += w_mean * metric(2);
-            mom(2) = rho_ln * w_mean;
-            h_hat += -0.25 * (w1 * w1 + w2 * w2) + w_mean * w_mean;
-        }
+    PointStateView S1{state1.GetData()};
+    PointStateView S2{state2.GetData()};
+    
+    const real_t rho1 = gasModel.density(S1);
+    const real_t rho2 = gasModel.density(S2);
+    const real_t rho_ln = ComputeLogMean(rho1, rho2);
+    const real_t drho = rho2 - rho1;
+    real_t mom[3] = {0.0, 0.0, 0.0};
+    real_t h_hat = 0.0;
+    real_t vn = 0.0;
+    real_t v_21 = 0.0;
+    real_t v_22 = 0.0;
+    for(int idim = 0; idim < dim; idim++){
+      real_t v1 = gasModel.velocity(S1, idim);
+      real_t v2 = gasModel.velocity(S2, idim);
+      real_t v_bar = 0.5*(v1 + v2);
+      v_21 += v1*v1;
+      v_22 += v2*v2;
+      vn += v_bar * metric(idim);
+      mom[idim] = rho_ln * v_bar;
+      h_hat += -0.25*(v1*v1 + v2*v2) + v_bar * v_bar;
     }
+    
+    const real_t p1 = gasModel.pressure(S1);
+    const real_t p2 = gasModel.pressure(S2);
 
-    p1 = gammaM1 * (state1(num_equations - 1) - 0.5 * rho1 * V_sq1);
-    p2 = gammaM1 * (state2(num_equations - 1) - 0.5 * rho2 * V_sq2);
+    const real_t speed1 = std::sqrt(v_21);
+    const real_t speed2 = std::sqrt(v_22);
 
-    V_mag1 = std::sqrt(V_sq1);
-    V_mag2 = std::sqrt(V_sq2);
+    const real_t c1 = gasModel.sound_speed(S1);
+    const real_t c2 = gasModel.sound_speed(S2);
 
-    lambda_max = V_mag1 + ComputeSoundSpeed(p1, rho1, gamma);
-    lambda_max = std::max(lambda_max, V_mag2 + ComputeSoundSpeed(p2, rho2, gamma));
+    const real_t lambda_1 = speed1 + c1;
+    const real_t lambda_max = std::max(lambda_1, speed2 + c2);
 
-    beta1 = 0.5 * rho1 / p1;
-    beta2 = 0.5 * rho2 / p2;
-    beta_ln = ComputeLogMean(beta1, beta2);
+    // These next bits are specific to single component ideal gas 
+    const real_t beta1 = 0.5 * rho1 / p1;
+    const real_t beta2 = 0.5 * rho2 / p2;
+    const real_t beta_ln = ComputeLogMean(beta1, beta2);
 
-    p_hat = 0.5 * (rho1 + rho2) / (beta1 + beta2);
+    const real_t p_hat = 0.5 * (rho1 + rho2) / (beta1 + beta2);
 
-    h_hat += 0.5 / beta_ln * gammaM1Inverse + p_hat / rho_ln;
+    // Use the average gamma for now
+    // TODO: Craft KEPEC fluxes for LTE/NLTE
+    const real_t gm11 = gasModel.gamma(S1);
+    const real_t gm12 = gasModel.gamma(S2);
+    const real_t gm1_av_inv = 2.0/(gm11 + gm12 - 2.0);
 
-    F_tilde(0) = rho_ln * Vn;
+    h_hat += 0.5 / beta_ln * gm1_av_inv + p_hat / rho_ln;
+
+    F_tilde(0) = rho_ln * vn;
     for (int d = 0; d < dim; d++)
     {
-        F_tilde(1 + d) = Vn * mom(d) + p_hat * metric(d);
+        F_tilde(1 + d) = vn * mom[d] + p_hat * metric(d);
     }
-    F_tilde(1 + dim) = rho_ln * Vn * h_hat;
+    F_tilde(1 + dim) = rho_ln * vn * h_hat;
 
     return lambda_max;
 }
@@ -85,77 +79,71 @@ real_t ChandrashekarFlux::ComputeVolumeFlux(const Vector &state1, const Vector &
 real_t ChandrashekarFlux::ComputeFaceFlux(const Vector &state1, const Vector &state2,
                                           const Vector &nor, Vector &flux) const
 {
-    nor_mag = nor.Norml2();
+    PointStateView S1{state1.GetData()};
+    PointStateView S2{state2.GetData()};
+    
+    const real_t nor_mag = nor.Norml2();
 
-    rho1 = state1(0);
-    rho2 = state2(0);
-    rho_mean = 0.5 * (rho1 + rho2);
-    rho_ln = ComputeLogMean(rho1, rho2);
-    drho = rho2 - rho1;
-
-    u1 = state1(1) / rho1;
-    u2 = state2(1) / rho2;
-    u_mean = 0.5 * (u1 + u2);
-    du = u2 - u1;
-    V_sq1 = u1 * u1;
-    V_sq2 = u2 * u2;
-    Vn = u_mean * nor(0);
-    mom(0) = rho_ln * u_mean;
-    h_hat = -0.25 * (u1 * u1 + u2 * u2) + u_mean * u_mean;
-    diss = 0.5 * drho * u1 * u2 + rho_mean * du * u_mean;
-
-    if (dim > 1)
-    {
-        v1 = state1(2) / rho1;
-        v2 = state2(2) / rho2;
-        v_mean = 0.5 * (v1 + v2);
-        dv = v2 - v1;
-        V_sq1 += v1 * v1;
-        V_sq2 += v2 * v2;
-        Vn += v_mean * nor(1);
-        mom(1) = rho_ln * v_mean;
-        h_hat += -0.25 * (v1 * v1 + v2 * v2) + v_mean * v_mean;
-        diss += 0.5 * drho * v1 * v2 + rho_mean * dv * v_mean;
-
-        if (dim > 2)
-        {
-            w1 = state1(3) / rho1;
-            w2 = state2(3) / rho2;
-            w_mean = 0.5 * (w1 + w2);
-            dw = w2 - w1;
-            V_sq1 += w1 * w1;
-            V_sq2 += w2 * w2;
-            Vn += w_mean * nor(2);
-            mom(2) = rho_ln * w_mean;
-            h_hat += -0.25 * (w1 * w1 + w2 * w2) + w_mean * w_mean;
-            diss += 0.5 * drho * w1 * w2 + rho_mean * dw + w_mean;
-        }
+    const real_t rho1 = gasModel.density(S1);
+    const real_t rho2 = gasModel.density(S2);
+    const real_t rho_mean = 0.5 * (rho1 + rho2);
+    const real_t rho_ln = ComputeLogMean(rho1, rho2);
+    const real_t drho = rho2 - rho1;
+    real_t mom[3] = {0.0, 0.0, 0.0};
+    real_t mom1[3] = {0.0, 0.0, 0.0};
+    real_t mom2[3] = {0.0, 0.0, 0.0};
+    real_t hhat = 0.0;
+    real_t diss = 0.0;
+    real_t v21 = 0.0;
+    real_t v22 = 0.0;
+    real_t vn = 0.0;
+    for(int idim = 0;idim < dim;idim++){
+      mom1[idim] = gasModel.momentum(S1, idim);
+      mom2[idim] = gasModel.momentum(S2, idim);
+      const real_t v1 = mom1[idim]/rho1;
+      const real_t v2 = mom2[idim]/rho2;
+      const real_t vbar = 0.5 * (v1 + v2);
+      const real_t dv = v2 - v1;
+      v21 += v1*v1;
+      v22 += v2*v2;
+      vn += vbar * nor(idim);
+      mom[idim] = rho_ln * vbar;
+      hhat += -0.25 * (v1*v1 + v2*v2) + vbar * vbar;
+      diss += 0.5 * drho * v1*v2 + rho_mean * dv * vbar;
     }
 
-    p1 = gammaM1 * (state1(num_equations - 1) - 0.5 * rho1 * V_sq1);
-    p2 = gammaM1 * (state2(num_equations - 1) - 0.5 * rho2 * V_sq2);
+    const real_t p1 = gasModel.pressure(S1);
+    const real_t p2 = gasModel.pressure(S2);
 
-    V_mag1 = std::sqrt(V_sq1);
-    V_mag2 = std::sqrt(V_sq2);
+    const real_t vmag1 = std::sqrt(v21);
+    const real_t vmag2 = std::sqrt(v22);
 
-    lambda_max = V_mag1 + ComputeSoundSpeed(p1, rho1, gamma);
-    lambda_max = std::max(lambda_max, V_mag2 + ComputeSoundSpeed(p2, rho2, gamma));
+    const real_t c1 = gasModel.sound_speed(S1);
+    const real_t c2 = gasModel.sound_speed(S2);
 
-    beta1 = 0.5 * rho1 / p1;
-    beta2 = 0.5 * rho2 / p2;
-    beta_ln = ComputeLogMean(beta1, beta2);
+    const real_t lambda_max = std::max(vmag1+c1, vmag2+c2);
 
-    p_hat = 0.5 * (rho1 + rho2) / (beta1 + beta2);
+    const real_t beta1 = 0.5 * rho1 / p1;
+    const real_t beta2 = 0.5 * rho2 / p2;
+    const real_t beta_ln = ComputeLogMean(beta1, beta2);
 
-    h_hat += 0.5 / beta_ln * gammaM1Inverse + p_hat / rho_ln;
-    diss += 0.5 * drho * gammaM1Inverse / beta_ln + 0.5 * rho_mean * gammaM1Inverse * (1.0 / beta2 - 1.0 / beta1);
+    const real_t p_hat = 0.5 * (rho1 + rho2) / (beta1 + beta2);
 
-    flux(0) = rho_ln * Vn - 0.5 * lambda_max * (rho2 - rho1) * nor_mag;
+    // Use the average gamma for now
+    // TODO: Craft KEPEC fluxes for LTE/NLTE
+    const real_t gm11 = gasModel.gamma(S1);
+    const real_t gm12 = gasModel.gamma(S2); 
+    const real_t gm1_av_inv = 2.0/(gm11 + gm12 - 2.0);
+
+    hhat += 0.5 / beta_ln * gm1_av_inv + p_hat / rho_ln;
+    diss += 0.5 * drho * gm1_av_inv / beta_ln + 0.5 * rho_mean * gm1_av_inv * (1.0 / beta2 - 1.0 / beta1);
+
+    flux(0) = rho_ln * vn - 0.5 * lambda_max * (rho2 - rho1) * nor_mag;
     for (int d = 0; d < dim; d++)
     {
-        flux(1 + d) = Vn * mom(d) + p_hat * nor(d) - 0.5 * lambda_max * (state2(1 + d) - state1(1 + d)) * nor_mag;
+      flux(1 + d) = vn * mom[d] + p_hat * nor(d) - 0.5 * lambda_max * (mom2[d]-mom1[d]) * nor_mag;
     }
-    flux(1 + dim) = rho_ln * Vn * h_hat - 0.5 * lambda_max * diss * nor_mag;
+    flux(1 + dim) = rho_ln * vn * hhat - 0.5 * lambda_max * diss * nor_mag;
 
     return lambda_max;
 }

--- a/src/RiemannSolvers/ChandrashekarFlux.hpp
+++ b/src/RiemannSolvers/ChandrashekarFlux.hpp
@@ -9,18 +9,12 @@ namespace Prandtl
 class ChandrashekarFlux : public NumericalFlux
 {
 private:
-    mutable real_t beta1, beta2;
-    mutable real_t p_hat, h_hat, rho_ln, beta_ln;
-    mutable real_t rho_mean, u_mean, v_mean, w_mean;
-    mutable Vector metric, mom;
-    mutable real_t lambda_max, diss;
-    mutable real_t drho, du, dv, dw;
-    mutable real_t rho1, rho2, u1, u2, v1, v2, w1, w2, p1, p2, V_sq1, V_sq2, V_mag1, V_mag2, Vn, nor_mag;
-    const real_t gamma, gammaM1, gammaM1Inverse;
+  mutable Vector metric;
+  const IdealGasModel gasModel;
 public:
-    ChandrashekarFlux(const NavierStokesFlux &fluxFunction, real_t gamma);
-    real_t ComputeFaceFlux(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux) const override;
-    real_t ComputeVolumeFlux(const Vector &state1, const Vector &state2, const Vector &metric1, const Vector &metric2, Vector &F_tilde) override;
+  ChandrashekarFlux(const NavierStokesFlux &fluxFunction, const IdealGasModel &gasModel_);
+  real_t ComputeFaceFlux(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux) const override;
+  real_t ComputeVolumeFlux(const Vector &state1, const Vector &state2, const Vector &metric1, const Vector &metric2, Vector &F_tilde) override;
 
 };
 

--- a/src/RiemannSolvers/LaxFriedrichsFlux.cpp
+++ b/src/RiemannSolvers/LaxFriedrichsFlux.cpp
@@ -10,8 +10,8 @@ real_t LaxFriedrichsFlux::Eval(const Vector &state1, const Vector &state2,
 #ifdef MFEM_THREAD_SAFE
    Vector fluxN1(fluxFunction.num_equations), fluxN2(fluxFunction.num_equations);
 #endif
-   const real_t speed1 = fluxFunction.ComputeFluxDotN(state1, nor, Tr, fluxN1);
-   const real_t speed2 = fluxFunction.ComputeFluxDotN(state2, nor, Tr, fluxN2);
+   const real_t speed1 = this->ComputeFluxDotN(state1, nor, Tr, fluxN1);
+   const real_t speed2 = this->ComputeFluxDotN(state2, nor, Tr, fluxN2);
    // NOTE: nor in general is not a unit normal
    const real_t maxE = std::max(speed1, speed2);
    // here, std::sqrt(nor*nor) is multiplied to match the scale with fluxN

--- a/src/RiemannSolvers/LaxFriedrichsFlux.hpp
+++ b/src/RiemannSolvers/LaxFriedrichsFlux.hpp
@@ -15,8 +15,8 @@ public:
      : FluxFunction(fluxFunction)
    {
 #ifndef MFEM_THREAD_SAFE
-      fluxN1.SetSize(fluxFunction.num_equations);
-      fluxN2.SetSize(fluxFunction.num_equations);
+      fluxN1.SetSize(num_equations);
+      fluxN2.SetSize(num_equations);
 #endif
    }
 

--- a/src/RiemannSolvers/LaxFriedrichsFlux.hpp
+++ b/src/RiemannSolvers/LaxFriedrichsFlux.hpp
@@ -8,11 +8,11 @@ namespace Prandtl
 using namespace mfem;
 
 
-class LaxFriedrichsFlux : public RiemannSolver
+class LaxFriedrichsFlux : public FluxFunction
 {
 public:
    LaxFriedrichsFlux(const FluxFunction &fluxFunction)
-      : RiemannSolver(fluxFunction)
+     : FluxFunction(fluxFunction)
    {
 #ifndef MFEM_THREAD_SAFE
       fluxN1.SetSize(fluxFunction.num_equations);
@@ -33,7 +33,7 @@ public:
     */
    real_t Eval(const Vector &state1, const Vector &state2,
                const Vector &nor, FaceElementTransformations &Tr,
-               Vector &flux) const override;
+               Vector &flux) const;
 
 protected:
 #ifndef MFEM_THREAD_SAFE

--- a/src/RiemannSolvers/RoeFlux.cpp
+++ b/src/RiemannSolvers/RoeFlux.cpp
@@ -12,8 +12,8 @@ real_t RoeFlux::Eval(const Vector &state1, const Vector &state2,
 #ifdef MFEM_THREAD_SAFE
    Vector fluxN1(fluxFunction.num_equations), fluxN2(fluxFunction.num_equations);
 #endif
-   const real_t speed1 = fluxFunction.ComputeFluxDotN(state1, nor, Tr, fluxN1);
-   const real_t speed2 = fluxFunction.ComputeFluxDotN(state2, nor, Tr, fluxN2);
+   const real_t speed1 = this->ComputeFluxDotN(state1, nor, Tr, fluxN1);
+   const real_t speed2 = this->ComputeFluxDotN(state2, nor, Tr, fluxN2);
    // NOTE: nor in general is not a unit normal
    const real_t maxE = std::max(speed1, speed2);
    // here, std::sqrt(nor*nor) is multiplied to match the scale with fluxN

--- a/src/RiemannSolvers/RoeFlux.hpp
+++ b/src/RiemannSolvers/RoeFlux.hpp
@@ -13,11 +13,11 @@ using namespace mfem;
  * where λ is the maximum characteristic velocity
  *
  */
-class RoeFlux : public RiemannSolver
+class RoeFlux : public FluxFunction
 {
 public:
    RoeFlux(const FluxFunction &fluxFunction)
-      : RiemannSolver(fluxFunction)
+      : FluxFunction(fluxFunction)
    {
 #ifndef MFEM_THREAD_SAFE
       fluxN1.SetSize(fluxFunction.num_equations);
@@ -38,7 +38,7 @@ public:
     */
    real_t Eval(const Vector &state1, const Vector &state2,
                const Vector &nor, FaceElementTransformations &Tr,
-               Vector &flux) const override;
+               Vector &flux) const;
 
 protected:
 #ifndef MFEM_THREAD_SAFE

--- a/src/RiemannSolvers/RoeFlux.hpp
+++ b/src/RiemannSolvers/RoeFlux.hpp
@@ -20,8 +20,8 @@ public:
       : FluxFunction(fluxFunction)
    {
 #ifndef MFEM_THREAD_SAFE
-      fluxN1.SetSize(fluxFunction.num_equations);
-      fluxN2.SetSize(fluxFunction.num_equations);
+      fluxN1.SetSize(num_equations);
+      fluxN2.SetSize(num_equations);
 #endif
    }
 

--- a/src/Simulation/Simulation.cpp
+++ b/src/Simulation/Simulation.cpp
@@ -438,10 +438,10 @@ void Simulation::LoadConfig(const std::string &config_file_path)
 
         for (int i = 0; i < num_dofs_scalar; ++i)
         {
-          real_t rho = fields.mass(i);
-          real_t rhoU = fields.momentum_x(i);
-          real_t rhoV = fields.momentum_y(i);
-          real_t E = fields.energy(i);
+          real_t rho = fields.mass(*stateLayout, i);
+          real_t rhoU = fields.momentum_x(*stateLayout, i);
+          real_t rhoV = fields.momentum_y(*stateLayout, i);
+          real_t E = fields.energy(*stateLayout, i);
           real_t z = zr[i].first;
           real_t r = zr[i].second;
 

--- a/src/Simulation/Simulation.cpp
+++ b/src/Simulation/Simulation.cpp
@@ -79,7 +79,7 @@ Simulation::~Simulation()
     }
 }
 
-bool debug_simulation = false;
+constexpr bool debug_simulation = false;
 
 void Simulation::LoadConfig(const std::string &config_file_path)
 {
@@ -205,21 +205,6 @@ void Simulation::LoadConfig(const std::string &config_file_path)
         return;
     }
 
-    flux = std::make_shared<NavierStokesFlux>(dim,
-        physicsConstants->gamma, physicsConstants->Pr, physicsConstants->mu, physicsConstants->mu0,
-        physicsConstants->mu_bulk, physicsConstants->R_gas, physicsConstants->Ts, physicsConstants->T0);
-
-    if (runtime["numerical_flux"].get<std::string>() == "Chandrashekar")
-    {
-        numericalFlux = std::make_shared<ChandrashekarFlux>(*flux, physicsConstants->gamma);
-    }
-    else
-    {
-        std::cerr << "Error: Invalid numerical flux specified." << std::endl;
-        return;
-    }
-
-
     signature = runtime["conditions"]["initial_conditions"].value("signature", 0);
     std::string IC_key = runtime["conditions"]["initial_conditions"].value("function", "LidDrivenCavityIC");
 
@@ -344,8 +329,17 @@ void Simulation::LoadConfig(const std::string &config_file_path)
 
     num_dofs_scalar = fes->GetNDofs();
     num_dofs_system = vfes->GetVSize();
-    
-    // sol = std::make_shared<ParGridFunction>(vfes.get());
+
+    stateLayout = std::make_shared<StateLayout>(dim, num_dofs_scalar);
+    gasModel = std::make_shared<IdealGasModel>(*physicsConstants, *stateLayout);
+
+    flux = std::make_shared<NavierStokesFlux>(*gasModel);
+    if (runtime["numerical_flux"].get<std::string>() == "Chandrashekar"){
+      numericalFlux = std::make_shared<ChandrashekarFlux>(*flux, *gasModel);
+    } else {
+      std::cerr << "Error: Invalid numerical flux specified." << std::endl;
+      return;
+    }
 
     if (checkpoint_load)
     {
@@ -415,6 +409,7 @@ void Simulation::LoadConfig(const std::string &config_file_path)
     if (debug_simulation)
     {
         real_t *sol_state = sol->GetData();
+        Prandtl::FieldStateView fields{sol_state};
         std::vector<std::pair<real_t, real_t>> zr(num_dofs_scalar, {0.0, 0.0});
 
         std::cout << "\n === sol state rU values after weighting by r ===\n";
@@ -443,14 +438,14 @@ void Simulation::LoadConfig(const std::string &config_file_path)
 
         for (int i = 0; i < num_dofs_scalar; ++i)
         {
-            real_t rho = sol_state[0*num_dofs_scalar+i];
-            real_t rhoU = sol_state[1*num_dofs_scalar+i];
-            real_t rhoV = sol_state[2*num_dofs_scalar+i];
-            real_t E = sol_state[3*num_dofs_scalar+i];
-            real_t z = zr[i].first;
-            real_t r = zr[i].second;
+          real_t rho = fields.mass(i);
+          real_t rhoU = fields.momentum_x(i);
+          real_t rhoV = fields.momentum_y(i);
+          real_t E = fields.energy(i);
+          real_t z = zr[i].first;
+          real_t r = zr[i].second;
 
-            std::cout << " DOF#" << std::setw(2) << i 
+          std::cout << " DOF#" << std::setw(2) << i 
                     << " (z, r) = ("<< std::fixed << std::setprecision(2) << std::setw(4) << z //std::round(z*100)/100.0
                     << ", " << std::setw(4) << std::round(r*100)/100.0 << "),  state = ["
                     << std::setw(4) << std::round(rho*100)/100.0 << ", "
@@ -468,9 +463,9 @@ void Simulation::LoadConfig(const std::string &config_file_path)
     eta = std::make_shared<ParGridFunction>(fes0.get());
     alpha = std::make_shared<ParGridFunction>(fes0.get());
 
-    dudx = std::make_shared<ParGridFunction>(vfes.get());
-    dudy = std::make_shared<ParGridFunction>(vfes.get());
-    dudz = std::make_shared<ParGridFunction>(vfes.get());
+    std::vector<std::shared_ptr<ParGridFunction> > grad_u(dim);
+    for(int idim = 0;idim < dim;idim++)
+      grad_u[idim] = std::make_shared<ParGridFunction>(vfes.get());
 
     Geometry::Type gtype = vfes->GetFE(0)->GetGeomType();
 
@@ -482,10 +477,16 @@ void Simulation::LoadConfig(const std::string &config_file_path)
     {
         alpha_max = 0.5;
     }
+    auto integrator =
+      std::make_unique<Prandtl::DGSEMIntegrator>(pmesh, fes0, alpha, liftingScheme, *numericalFlux, order+1);
 
-    NS = std::make_unique<DGSEMOperator>(vfes, fes0, pmesh, eta, alpha, dudx, dudy, dudz,
-        std::make_unique<Prandtl::DGSEMIntegrator>(pmesh, fes0, alpha, liftingScheme, *numericalFlux, order + 1, physicsConstants->gamma),
-        std::make_unique<Prandtl::PerssonPeraireIndicator>(vfes, fes0, eta, std::make_shared<Prandtl::ModalBasis>(*fec, gtype, order, dim), physicsConstants->gamma), physicsConstants->gamma, r_gf, alpha_max);
+    auto indicator =
+      std::make_unique<Prandtl::PerssonPeraireIndicator>(vfes, fes0, eta,
+                                                         std::make_unique<Prandtl::ModalBasis>(*fec, gtype, order, dim),
+                                                         *gasModel);
+
+    NS = std::make_unique<DGSEMOperator>(vfes, fes0, pmesh, eta, alpha, grad_u, std::move(integrator),
+                                         std::move(indicator), *gasModel, r_gf, alpha_max);
 
     if (runtime["conditions"].contains("boundary_conditions"))
     {
@@ -519,9 +520,10 @@ void Simulation::LoadConfig(const std::string &config_file_path)
 
             if (type == "symmetry" || type == "axis")
             {
-                auto symmetry = std::make_unique<SymmetryBdrFaceIntegrator>(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma, true, false);
-
-                NS->AddBdrFaceIntegrator(symmetry.release(), bdr_marker_vector.back());
+              auto symmetry = std::make_unique<SymmetryBdrFaceIntegrator>(liftingScheme, *gasModel, *numericalFlux,
+                                                                          order + 1, NS->GetTimeRef(), true, false);
+              
+              NS->AddBdrFaceIntegrator(symmetry.release(), bdr_marker_vector.back());
 
 #ifdef AXISYMMETRIC
                 if (type == "axis")
@@ -533,7 +535,8 @@ void Simulation::LoadConfig(const std::string &config_file_path)
             }
             else if (type == "slip")
             {
-                auto slip = std::make_unique<SlipWallBdrFaceIntegrator>(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma, true, false);
+              auto slip = std::make_unique<SlipWallBdrFaceIntegrator>(liftingScheme, *gasModel, *numericalFlux,
+                                                                      order + 1, NS->GetTimeRef(), true, false);
 
                 NS->AddBdrFaceIntegrator(slip.release(), bdr_marker_vector.back());
 
@@ -545,9 +548,9 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                     std::string velBC_key = bc_props["velocity"]["vector"].get<std::string>();
                     std::string heatBC_key = bc_props["heat"]["scalar"].get<std::string>();
                     NS->AddBdrFaceIntegrator(
-                        new NoSlipAdiabWallBdrFaceIntegrator(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma,
-                            ConditionFactory::Instance().GetScalarBoundaryCondition(heatBC_key),
-                            ConditionFactory::Instance().GetVectorBoundaryCondition(velBC_key)), bdr_marker_vector.back());
+           new NoSlipAdiabWallBdrFaceIntegrator(liftingScheme, *gasModel, *numericalFlux, order + 1, NS->GetTimeRef(),
+                                                ConditionFactory::Instance().GetScalarBoundaryCondition(heatBC_key),
+                                                ConditionFactory::Instance().GetVectorBoundaryCondition(velBC_key)), bdr_marker_vector.back());
                 }
                 else if (bc_props["velocity"].contains("function"))
                 {
@@ -629,7 +632,10 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                     }
 
                     NS->AddBdrFaceIntegrator(
-                        new NoSlipAdiabWallBdrFaceIntegrator(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma, *heatBC, *velBC, td), bdr_marker_vector.back());
+                                             new NoSlipAdiabWallBdrFaceIntegrator(liftingScheme, *gasModel,
+                                                                                  *numericalFlux, order + 1, NS->GetTimeRef(),
+                                                                                  *heatBC, *velBC, td),
+                                             bdr_marker_vector.back());
                 }
                 else
                 {
@@ -643,7 +649,8 @@ void Simulation::LoadConfig(const std::string &config_file_path)
             }
             else if (type == "supersonic-outflow")
             {
-                auto outlet = std::make_unique<SupersonicOutflowBdrFaceIntegrator>(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma);
+              auto outlet = std::make_unique<SupersonicOutflowBdrFaceIntegrator>(liftingScheme, *gasModel,
+                                                                                 *numericalFlux, order + 1, NS->GetTimeRef());
 
                 NS->AddBdrFaceIntegrator(outlet.release(), bdr_marker_vector.back());
 
@@ -653,11 +660,12 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                 if (bc_props.contains("vector"))
                 {
                 std::string state_key = bc_props["vector"].get<std::string>();
-                auto inlet = std::make_unique<SupersonicInflowBdrFaceIntegrator>(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma,
-                        ConditionFactory::Instance().GetVectorBoundaryCondition(state_key));
-
-                    NS->AddBdrFaceIntegrator(inlet.release(), bdr_marker_vector.back());
-
+                auto inlet = std::make_unique<SupersonicInflowBdrFaceIntegrator>(
+                                                              liftingScheme, *gasModel, 
+                                                              *numericalFlux, order + 1, NS->GetTimeRef(),
+                                                              ConditionFactory::Instance().GetVectorBoundaryCondition(state_key));
+                NS->AddBdrFaceIntegrator(inlet.release(), bdr_marker_vector.back());
+                
                 }
                 else
                 {
@@ -715,8 +723,8 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                         std::cerr << "Error: Invalid boundary condition signature." << std::endl;
                         return;
                     }
-                    auto inlet = std::make_unique<SupersonicInflowBdrFaceIntegrator>(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma,
-                        *stateBC, td);
+                    auto inlet = std::make_unique<SupersonicInflowBdrFaceIntegrator>(liftingScheme, *gasModel, *numericalFlux,
+                                                                                     order + 1, NS->GetTimeRef(), *stateBC, td);
 
                     NS->AddBdrFaceIntegrator(inlet.release(), bdr_marker_vector.back());
 
@@ -727,7 +735,8 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                 if (bc_props.contains("vector"))
                 {
                     std::string state_key = bc_props["vector"].get<std::string>();
-                    NS->AddBdrFaceIntegrator(new SpecifiedStateBdrFaceIntegrator(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma,
+                    NS->AddBdrFaceIntegrator(new SpecifiedStateBdrFaceIntegrator(liftingScheme, *gasModel, *numericalFlux,
+                                                                                 order + 1, NS->GetTimeRef(),
                         ConditionFactory::Instance().GetVectorBoundaryCondition(state_key)), bdr_marker_vector.back());
                 }
                 else
@@ -786,7 +795,8 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                         std::cerr << "Error: Invalid boundary condition signature." << std::endl;
                         return;
                     }
-                    NS->AddBdrFaceIntegrator(new SpecifiedStateBdrFaceIntegrator(liftingScheme, *numericalFlux, order + 1, NS->GetTimeRef(), physicsConstants->gamma, *stateBC, td), bdr_marker_vector.back());
+                    NS->AddBdrFaceIntegrator(new SpecifiedStateBdrFaceIntegrator(liftingScheme, *gasModel, *numericalFlux, order + 1, NS->GetTimeRef(),
+                                                                                 *stateBC, td), bdr_marker_vector.back());
                 }
             }
             else
@@ -806,9 +816,9 @@ void Simulation::LoadConfig(const std::string &config_file_path)
     NS->SetTime(t);
     ode_solver->Init(*NS);
 
-    rho.MakeRef(fes.get(), *sol, 0);
-    mom.MakeRef(dfes.get(), *sol, num_dofs_scalar);
-    energy.MakeRef(fes.get(), *sol, (dim + 1) * num_dofs_scalar);
+    rho.MakeRef(fes.get(), *sol, offset_mass(*stateLayout));
+    mom.MakeRef(dfes.get(), *sol, offset_momentum(*stateLayout));
+    energy.MakeRef(fes.get(), *sol, offset_energy(*stateLayout));
 
     u = std::make_unique<ParGridFunction>(fes.get());
     if (dim > 1)
@@ -921,22 +931,35 @@ void Simulation::Run()
 #endif
     if (Mpi::Root())
         {
-            int i = 0;  
+          int i = 0;
 #ifdef AXISYMMETRIC
-            real_t rhoi = (*rho_axi)(i);
-            real_t ui = (*u)(i);               
-            real_t vi = (*v)(i);
-            real_t pi = (*p)(i);
-
-            NS->SetAxisFloorsFromFreestream(rhoi, pi);
+          real_t rhoi = (*rho_axi)(i);
+          real_t ui = (*u)(i);               
+          real_t vi = (*v)(i);
+          real_t pi = (*p)(i);
+          
+          NS->SetAxisFloorsFromFreestream(rhoi, pi);
 #else
-            real_t rhoi = rho(i);
-            real_t ui = mom(i)/rhoi;               
-            real_t vi = mom(i + num_dofs_scalar)/rhoi;
-            real_t pi = physicsConstants->gammaM1 * (energy(i) - 0.5*rhoi*ui*ui);
+          real_t *sol_state = sol->GetData();
+          Prandtl::DofStateView dofState{sol_state, i};
+          real_t rhoi = gasModel->density(dofState);
+          real_t ui = gasModel->velocity(dofState, 0);
+          real_t vi = dim > 1 ? gasModel->velocity(dofState, 1) : 0.0;
+          real_t wi = dim > 2 ? gasModel->velocity(dofState, 2) : 0.0;
+          real_t pi = gasModel->pressure(dofState);
+          // bug: incorrect calculation of kinetic energy
+          //real_t pi = physicsConstants->gammaM1 * (energy(i) - 0.5*rhoi*ui*ui);
 #endif
-            std::cout << "***  initial at dof #" << i << ":  "
-                        << "rho = " << std::round(rhoi*10000)/10000 << ",  u = " << std::round(ui*100)/100 << ",  v = " << std::round(vi*100)/100 << ",  p = " << std::round(pi*100)/100 << "\n";
+          std::cout << "***  initial at dof #" << i << ":  "
+                    << "rho = " << std::round(rhoi*10000)/10000 << ",  velocity = <"
+                    << std::round(ui*100)/100;
+          if(dim > 1){
+            std::cout << ", " << std::round(vi*100)/100;
+            if(dim > 2){
+              std::cout << ", " << std::round(wi*100)/100;
+            }
+          }
+          std::cout << ">, p = " << std::round(pi*100)/100 << std::endl;
         }
     // Visualize the initial condition?
     if (visualize)
@@ -959,21 +982,20 @@ void Simulation::Run()
 
         
 #else
+        real_t *sol_state = sol->GetData();
         for (int i = 0; i < num_dofs_scalar; i++)
-        {
-            (*u)(i) = mom(i) / rho(i);
-            V_sq = (*u)(i) * (*u)(i);
+          {
+            Prandtl::DofStateView dofState{sol_state, i};
+            (*u)(i) = gasModel->velocity(dofState,0);
             if (dim > 1)
             {
-                (*v)(i) = mom(i + num_dofs_scalar) / rho(i);
-                V_sq += (*v)(i) * (*v)(i);
-                if (dim > 2)
+              (*v)(i) = gasModel->velocity(dofState, 1);
+              if (dim > 2)
                 {
-                    (*w)(i) = mom(i + 2 * num_dofs_scalar) / rho(i);
-                    V_sq += (*w)(i) * (*w)(i);
+                  (*w)(i) = gasModel->velocity(dofState, 2);
                 }
             }
-            (*p)(i) = physicsConstants->gammaM1 * (energy(i) - 0.5 * rho(i) * V_sq);
+            (*p)(i) = gasModel->pressure(dofState);
         }
 #endif
 
@@ -1043,21 +1065,20 @@ void Simulation::Run()
         NS->RecoverStateFromWeighted(*sol, U_cons);
         ConservativeToPrimitive(U_cons, *rho_axi, *u, *v, *p);
 #else
+        real_t *sol_state = sol->GetData();
         for (int i = 0; i < num_dofs_scalar; i++)
         {       
-                (*u)(i) = mom(i) / rho(i);
-                V_sq = (*u)(i) * (*u)(i);
-                if (dim > 1)
+          Prandtl::DofStateView dofState{sol_state, i};
+          (*u)(i) = gasModel->velocity(dofState, 0);
+          if (dim > 1)
+            {
+              (*v)(i) = gasModel->velocity(dofState, 1);
+              if (dim > 2)
                 {
-                    (*v)(i) = mom(i + num_dofs_scalar) / rho(i);
-                    V_sq += (*v)(i) * (*v)(i);
-                    if (dim > 2)
-                    {
-                        (*w)(i) = mom(i + 2 * num_dofs_scalar) / rho(i);
-                        V_sq += (*w)(i) * (*w)(i);
-                    }
+                  (*w)(i) = gasModel->velocity(dofState, 2);
                 }
-                (*p)(i) = physicsConstants->gammaM1 * (energy(i) - 0.5 * rho(i) * V_sq);
+            }
+          (*p)(i) = gasModel->pressure(dofState);
         }
 #endif
 

--- a/src/Simulation/Simulation.hpp
+++ b/src/Simulation/Simulation.hpp
@@ -11,124 +11,125 @@ using namespace mfem;
 class Simulation
 {
 private:
-    int numProcs, myRank;
-    int order;
-    int dim;
-    int num_equations;
-    int ref_levels;
-    int vis_steps;
-    int nancheck_steps;
-    int precision;
-    int num_dofs_scalar;
-    int num_dofs_system;
-    int print_interval;
-    int ti;
-    int checkpoint_cycle;
+  int numProcs, myRank;
+  int order;
+  int dim;
+  int num_equations;
+  int ref_levels;
+  int vis_steps;
+  int nancheck_steps;
+  int precision;
+  int num_dofs_scalar;
+  int num_dofs_system;
+  int print_interval;
+  int ti;
+  int checkpoint_cycle;
+  
+  bool done = false;
+  bool variable_dt = false;
+  bool clock_simulation = true;
+  bool nancheck = false;
+  bool visualize = true;
+  bool visit = false;
+  bool paraview = true;
+  bool checkpoint_load = false;
+  bool checkpoint_save = false;
+  
+  std::shared_ptr<PhysicsConstants> physicsConstants;
+  std::shared_ptr<StateLayout> stateLayout;
+  std::shared_ptr<IdealGasModel> gasModel;
 
-    bool done = false;
-    bool variable_dt = false;
-    bool clock_simulation = true;
-    bool nancheck = false;
-    bool visualize = true;
-    bool visit = false;
-    bool paraview = true;
-    bool checkpoint_load = false;
-    bool checkpoint_save = false;
-
-    std::shared_ptr<PhysicsConstants> physicsConstants;
-
-    std::string output_file_path;
-    std::string paraview_folder;
-    std::string checkpoints_folder;
-
-    real_t t, t_final, dt, dt_real;
-    real_t cfl;
-    real_t hmin;
-    real_t Re, Ma;
-    real_t next_save_t;
-    real_t save_dt1;
-    real_t save_dt2;
-    real_t trigger_t;
-    real_t save_dt;
-    real_t next_checkpoint_t;
-    real_t checkpoint_dt;
-
-    real_t V_sq;
-
-    real_t alpha_max;
-
-    Array<int> mesh_ordering;
-    std::shared_ptr<ParMesh> pmesh;
-
-    int btype = BasisType::GaussLobatto;
-    int ordering = Ordering::byNODES;
-    std::shared_ptr<DG_FECollection> fec;
-    std::shared_ptr<DG_FECollection> fec0;
-    std::shared_ptr<ParFiniteElementSpace> vfes;
-    std::shared_ptr<ParFiniteElementSpace> fes0;
-    std::unique_ptr<ParFiniteElementSpace> fes;
-    std::unique_ptr<ParFiniteElementSpace> dfes;
-
-    std::unique_ptr<VectorFunctionCoefficient> u0;
-
-    std::shared_ptr<ParGridFunction> sol;
-    std::shared_ptr<ParGridFunction> dudx;
-    std::shared_ptr<ParGridFunction> dudy;
-    std::shared_ptr<ParGridFunction> dudz;
-
-    std::shared_ptr<ParGridFunction> eta;
-    std::shared_ptr<ParGridFunction> alpha;
-    std::shared_ptr<ParGridFunction> r_gf;
-    
-    std::shared_ptr<NavierStokesFlux> flux;
-    std::shared_ptr<NumericalFlux> numericalFlux;
-
-    std::shared_ptr<LiftingScheme> liftingScheme;
-    std::vector<std::shared_ptr<VectorFunctionCoefficient>> BC_coeff;
-
-    FunctionCoefficient r_coef, z_coef;
-    
-    ParGridFunction rho, mom, energy;
-    
-    std::unique_ptr<ParGridFunction> u, v, w;
-    std::unique_ptr<ParGridFunction> p, rho_axi;
-
-
-    std::unique_ptr<ParaViewDataCollection> pd;
-    std::unique_ptr<VisItDataCollection> vd;
-
-    std::shared_ptr<ODESolver> ode_solver;
-    std::unique_ptr<DGSEMOperator> NS;
-
-    int signature;
-
-    std::shared_ptr<BdrFaceIntegrator> bdr_face_integrator;
-    std::vector<Array<int>> bdr_marker_vector;
-    Array<int> set_marker;
-    int max_bdr_attr;
-
+  std::string output_file_path;
+  std::string paraview_folder;
+  std::string checkpoints_folder;
+  
+  real_t t, t_final, dt, dt_real;
+  real_t cfl;
+  real_t hmin;
+  real_t Re, Ma;
+  real_t next_save_t;
+  real_t save_dt1;
+  real_t save_dt2;
+  real_t trigger_t;
+  real_t save_dt;
+  real_t next_checkpoint_t;
+  real_t checkpoint_dt;
+  
+  real_t V_sq;
+  
+  real_t alpha_max;
+  
+  Array<int> mesh_ordering;
+  std::shared_ptr<ParMesh> pmesh;
+  
+  int btype = BasisType::GaussLobatto;
+  int ordering = Ordering::byNODES;
+  std::shared_ptr<DG_FECollection> fec;
+  std::shared_ptr<DG_FECollection> fec0;
+  std::shared_ptr<ParFiniteElementSpace> vfes;
+  std::shared_ptr<ParFiniteElementSpace> fes0;
+  std::unique_ptr<ParFiniteElementSpace> fes;
+  std::unique_ptr<ParFiniteElementSpace> dfes;
+  
+  std::unique_ptr<VectorFunctionCoefficient> u0;
+  
+  std::shared_ptr<ParGridFunction> sol;
+  std::shared_ptr<ParGridFunction> dudx;
+  std::shared_ptr<ParGridFunction> dudy;
+  std::shared_ptr<ParGridFunction> dudz;
+  
+  std::shared_ptr<ParGridFunction> eta;
+  std::shared_ptr<ParGridFunction> alpha;
+  std::shared_ptr<ParGridFunction> r_gf;
+  
+  std::shared_ptr<NavierStokesFlux> flux;
+  std::shared_ptr<NumericalFlux> numericalFlux;
+  
+  std::shared_ptr<LiftingScheme> liftingScheme;
+  std::vector<std::shared_ptr<VectorFunctionCoefficient>> BC_coeff;
+  
+  FunctionCoefficient r_coef, z_coef;
+  
+  ParGridFunction rho, mom, energy;
+  
+  std::unique_ptr<ParGridFunction> u, v, w;
+  std::unique_ptr<ParGridFunction> p, rho_axi;
+  
+  std::unique_ptr<ParaViewDataCollection> pd;
+  std::unique_ptr<VisItDataCollection> vd;
+  
+  std::shared_ptr<ODESolver> ode_solver;
+  std::unique_ptr<DGSEMOperator> NS;
+  
+  int signature;
+  
+  std::shared_ptr<BdrFaceIntegrator> bdr_face_integrator;
+  std::vector<Array<int>> bdr_marker_vector;
+  Array<int> set_marker;
+  int max_bdr_attr;
+  
 #ifdef AXISYMMETRIC
-    void ConservativeToPrimitive(const Vector &U_cons,
-                                ParGridFunction &rho_out,
-                                ParGridFunction &uz_out,
-                                ParGridFunction &ur_out,
-                                ParGridFunction &p_out) const;  
+  void ConservativeToPrimitive(const Vector &U_cons,
+                               ParGridFunction &rho_out,
+                               ParGridFunction &uz_out,
+                               ParGridFunction &ur_out,
+                               ParGridFunction &p_out) const;  
 #endif
-
-    Simulation();
-
-    // change some shared_ptrs to unique_ptrs
-
+  
+  Simulation();
+  
+  // change some shared_ptrs to unique_ptrs
+  
 public:    
-    static Simulation& SimulationCreate();
-    void LoadConfig(const std::string &config_file_path);
-
-    ~Simulation();
-
-    void Run();
-
-    Simulation(const Simulation&) = delete;
-    Simulation& operator = (const Simulation&) = delete;
+  static Simulation& SimulationCreate();
+  void LoadConfig(const std::string &config_file_path);
+  
+  ~Simulation();
+  
+  void Run();
+  
+  Simulation(const Simulation&) = delete;
+  Simulation& operator = (const Simulation&) = delete;
 };
-
+  
 }


### PR DESCRIPTION
## ⚠️ This PR is part of a cascade of PRs which should be reviewed in order:

1. #37 Fixes a bug in Prandtl
2. #38 Updates to POD version of GasModel
3. #39 (this one) Updates Prandtl to use the new GasModel

--------

## Pull request overview

This PR refactors the Prandtl codebase to use a new `GasModel` abstraction layer, replacing direct gamma-based thermodynamic calculations with a more flexible gas model interface.

**Changes:**
- Introduces `IdealGasModel` and `StateLayout` abstractions to centralize thermodynamic property calculations and state data layout
- Replaces hard-coded equation indices with layout-based accessors throughout the codebase
- Updates all boundary condition integrators, flux functions, and operators to use the new gas model API
- Refactors Riemann solvers to inherit from `FluxFunction` instead of `RiemannSolver`

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/Simulation/Simulation.hpp | Added gasModel and stateLayout members, reformatted indentation |
| src/Simulation/Simulation.cpp | Updated to construct and use gasModel/stateLayout throughout initialization and runtime |
| src/RiemannSolvers/RoeFlux.hpp | Changed inheritance from RiemannSolver to FluxFunction |
| src/RiemannSolvers/RoeFlux.cpp | Updated to use inherited num_equations member |
| src/RiemannSolvers/LaxFriedrichsFlux.hpp | Changed inheritance from RiemannSolver to FluxFunction |
| src/RiemannSolvers/LaxFriedrichsFlux.cpp | Updated to use inherited num_equations member |
| src/RiemannSolvers/ChandrashekarFlux.hpp | Replaced gamma members with gasModel member |
| src/RiemannSolvers/ChandrashekarFlux.cpp | Refactored to use gasModel API for all thermodynamic calculations |
| src/Operators/DGSEMOperator.hpp | Added gasModel member, replaced individual grad members with grad_u vector |
| src/Operators/DGSEMOperator.cpp | Updated to use gasModel for entropy/gradient conversions |
| src/Integrators/DGSEMIntegrator/DGSEMIntegrator.hpp | Removed gamma parameter from constructor |
| src/Integrators/DGSEMIntegrator/DGSEMIntegrator.cpp | Replaced PressureFromConservative with fluxFunction.pressure() call |
| src/Integrators/BoundaryConditions/*.hpp | All boundary integrators updated to accept gasModel parameter |
| src/Integrators/BoundaryConditions/*.cpp | All boundary integrators refactored to use gasModel and StateLayout |
| src/Indicators/PerssonPeraireIndicator.hpp | Replaced gamma member with gasModel |
| src/Indicators/PerssonPeraireIndicator.cpp | Updated to use gasModel.pressure() and gasModel.density() |
| src/Fluxes/NavierStokesFlux.hpp | Simplified to wrap gasModel, removed explicit thermodynamic parameters |
| src/Fluxes/NavierStokesFlux.cpp | Refactored viscous flux and inviscid flux calculations using gasModel API |
| src/BasicOperations/BasicOperations.hpp | Added template functions for gas model-based conversions |
| src/BasicOperations/BasicOperations.cpp | Added StateLayout-aware RotateState/RotateBack overloads |
</details>


##### (copilot-generated)