### PR TITLE
Add device ready mfem/infrastructure

### DIFF
--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -81,23 +81,21 @@ jobs:
 
       - name: Configure Prandtl (Euler)
         env:
-          CONFIG_FILE: compile_config.json
+          # CONFIG_FILE: compile_config.json
           CC: ${{ env.CC }}
           CXX: ${{ env.CXX }}
           FC: ${{ env.FC }}
           # These paths match your script’s build outputs
-          MFEM_DIR: ${{ github.workspace }}/libs/mfem
-          HYPRE_DIR: ${{ github.workspace }}/libs/hypre/src/hypre
-          METIS_DIR: ${{ github.workspace }}/libs/metis-5.1.0
+          MFEM_DIR: ${{ github.workspace }}/libs/mfem/build
+          # HYPRE_DIR: ${{ github.workspace }}/libs/hypre/src/hypre
+          # METIS_DIR: ${{ github.workspace }}/libs/metis-5.1.0
         run: |
           mkdir -p build-euler
+          #  -DCONFIG_FILE=${CONFIG_FILE}
           cmake -S . -B build-euler -G Ninja \
-            -DCONFIG_FILE=${CONFIG_FILE} \
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
             -DBUILD_TESTING=ON \
-            -DMFEM_DIR="${MFEM_DIR}" \
-            -DHYPRE_DIR="${HYPRE_DIR}" \
-            -DMETIS_DIR="${METIS_DIR}" \
+            -DCMAKE_PREFIX_PATH=${MFEM_DIR} \
             -DSUBCELL_FV_BLENDING=ON
 
       - name: Build Prandtl (Euler)
@@ -112,23 +110,21 @@ jobs:
 
       - name: Configure Prandtl (CNS)
         env:
-          CONFIG_FILE: compile_config.json
+          # CONFIG_FILE: compile_config.json
           CC: ${{ env.CC }}
           CXX: ${{ env.CXX }}
           FC: ${{ env.FC }}
           # These paths match your script’s build outputs
-          MFEM_DIR: ${{ github.workspace }}/libs/mfem
-          HYPRE_DIR: ${{ github.workspace }}/libs/hypre/src/hypre
-          METIS_DIR: ${{ github.workspace }}/libs/metis-5.1.0
+          MFEM_DIR: ${{ github.workspace }}/libs/mfem/build
+          # HYPRE_DIR: ${{ github.workspace }}/libs/hypre/src/hypre
+          # METIS_DIR: ${{ github.workspace }}/libs/metis-5.1.0
         run: |
           mkdir -p build-cns
+          #  -DCONFIG_FILE=${CONFIG_FILE}
           cmake -S . -B build-cns -G Ninja \
-            -DCONFIG_FILE=${CONFIG_FILE} \
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
             -DBUILD_TESTING=ON \
-            -DMFEM_DIR="${MFEM_DIR}" \
-            -DHYPRE_DIR="${HYPRE_DIR}" \
-            -DMETIS_DIR="${METIS_DIR}" \
+            -DCMAKE_PREFIX_PATH=${MFEM_DIR} \
             -DPARABOLIC=ON -DSUBCELL_FV_BLENDING=ON
 
       - name: Build Prandtl (CNS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# set(CMAKE_CXX_COMPILER ${MPICXX})
-# set(MPI_CXX_INCLUDE_PATH "")
-# set(MPI_CXX_LIBRARIES "")
-
 project(Prandtl)
 
 option(BUILD_TESTING "Build unit tests" ON)
@@ -16,13 +12,16 @@ option(SUBCELL_FV_BLENDING "Enable subcell blending" ON)
 option(AXISYMMETRIC "Enable Axisymmetric domain solver" OFF)
 option(SUTHERLAND "Enable Sutherland transport model" OFF)
 
-find_package(MPI REQUIRED)
-include_directories(${MPI_CXX_INCLUDE_PATH})
-set(MPI_CXX_LIBRARIES ${MPI_CXX_LIBRARIES})
+find_package(MFEM REQUIRED CONFIG) 
+if (TARGET MFEM::mfem)
+  set(PRANDTL_MFEM_TARGET MFEM::mfem)
+elseif (TARGET mfem)
+  set(PRANDTL_MFEM_TARGET mfem)
+else()
+  message(FATAL_ERROR "MFEM package found, but no MFEM target (MFEM::mfem or mfem) was provided.")
+endif()
 
-message(STATUS "MPI CXX COMPILER: ${MPI_CXX_COMPILER}")
-message(STATUS "MPI INCLUDE PATH: ${MPI_INCLUDE_PATH}")
-message(STATUS "MPI LIBRARIES: ${MPI_CXX_LIBRARIES}")
+find_package(MPI REQUIRED)
 
 add_executable(${PROJECT_NAME} main.cpp)
 
@@ -62,6 +61,8 @@ endif()
 if(SUBCELL_FV_BLENDING)
   message(STATUS "Building Prandtl with: Subcell FV Blending enabled")
   target_compile_definitions(${PROJECT_NAME} PRIVATE SUBCELL_FV_BLENDING)
+else()
+  message(STATUS "Building Prandtl with: Subcell FV Blending OFF")
 endif()
 
 if(SUTHERLAND)
@@ -72,6 +73,60 @@ endif()
 if(AXISYMMETRIC)
   message(STATUS "Building Prandtl with: Axisymmetric domain enabled")
   target_compile_definitions(${PROJECT_NAME} PRIVATE AXISYMMETRIC)
+endif()
+
+# -------------------------------------------------------------------------------
+# Target-local sanitizers for a single executable (Clang/AppleClang/GNU)
+# -------------------------------------------------------------------------------
+
+option(ENABLE_ASAN_UBSAN "Enable ASan+UBSan for the main executable" OFF)
+
+if (ENABLE_ASAN_UBSAN AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
+  message(STATUS "Enabling ASan+UBSan on target: ${PROJECT_NAME}")
+
+  # Compile flags
+  target_compile_options(${PROJECT_NAME} PRIVATE
+    -O1
+    -g
+    -fno-fast-math
+    -ffp-contract=off
+    -fno-unsafe-math-optimizations
+    -fno-associative-math
+    -fno-reciprocal-math
+    -fno-omit-frame-pointer
+    -fno-optimize-sibling-calls
+    -fsanitize=address,undefined
+  )
+
+  # Link flags
+  target_link_options(${PROJECT_NAME} PRIVATE
+    -fsanitize=address,undefined
+  )
+
+  # Prefer hard-fail on first UB to get the cleanest stack trace
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_compile_options(${PROJECT_NAME} PRIVATE -fno-sanitize-recover=all)
+  endif()
+endif()
+
+option(NO_OPT "Disable optimizations for testing" OFF)
+
+if (NO_OPT AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
+  message(STATUS "Disabling all optimizations on target: myexe")
+
+  # Compile flags
+  target_compile_options(${PROJECT_NAME} PRIVATE
+    -O0
+    -g
+    -fno-fast-math
+    -ffp-contract=off
+    -fno-unsafe-math-optimizations
+    -fno-associative-math
+    -fno-reciprocal-math
+    -fno-omit-frame-pointer
+    -fno-optimize-sibling-calls
+  )
+
 endif()
 
 target_sources(${PROJECT_NAME}
@@ -107,12 +162,9 @@ target_sources(${PROJECT_NAME}
     )
 
 target_include_directories(${PROJECT_NAME}
-    PUBLIC ${CMAKE_SOURCE_DIR}/libs/mfem
-    PUBLIC ${CMAKE_SOURCE_DIR}/libs/hypre/src/hypre/include
-    PUBLIC ${CMAKE_SOURCE_DIR}/libs/metis-5.1.0/include
+    PUBLIC ${CMAKE_SOURCE_DIR}/src/Device
     PUBLIC ${CMAKE_SOURCE_DIR}/src/Operators/NonlinearForm
     PUBLIC ${CMAKE_SOURCE_DIR}/src/Operators
-    PUBLIC ${CMAKE_SOURCE_DIR}/src/Device
     PUBLIC ${CMAKE_SOURCE_DIR}/src/RiemannSolvers
     PUBLIC ${CMAKE_SOURCE_DIR}/src/BasicOperations
     PUBLIC ${CMAKE_SOURCE_DIR}/src/Filters
@@ -150,13 +202,11 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC ${CMAKE_SOURCE_DIR}/TestCases/Euler/2D/Nagashima_Ramjet
     )
 
-target_link_directories(${PROJECT_NAME}
-    PUBLIC ${CMAKE_SOURCE_DIR}/libs/mfem
-    PUBLIC ${CMAKE_SOURCE_DIR}/libs/hypre/src/lib
-    PUBLIC ${CMAKE_SOURCE_DIR}/libs/metis-5.1.0/lib
-    )
-
-target_link_libraries(${PROJECT_NAME} mfem HYPRE metis MPI::MPI_CXX)
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    ${PRANDTL_MFEM_TARGET}
+    MPI::MPI_CXX
+)
 
 if (BUILD_TESTING)
   include(CTest)

--- a/build_depends.sh
+++ b/build_depends.sh
@@ -34,9 +34,13 @@ cd ../../
 # --- Step 3: Build Parallel MFEM ---
 echo "--- Building Parallel MFEM ---"
 cd libs/mfem/
-make distclean
-make parallel -j4 MFEM_USE_METIS_5=YES METIS_DIR="$(cd ../metis-5.1.0/ && pwd)" HYPRE_DIR="$(cd ../hypre/src/hypre && pwd)"
-cd ../../
+mkdir build
+export METIS_DIR="$(cd ../metis-5.1.0/ && pwd)"
+export HYPRE_DIR="$(cd ../metis-5.1.0/ && pwd)"
+cd build
+cmake ../ -DMFEM_USE_METIS_5=YES -DMFEM_USE_MPI=YES
+make -j 4
+cd ../../../
 
 # --- Step 4: Build GLVis ---
 if [ "$IS_HPC" = false ]; then

--- a/main.cpp
+++ b/main.cpp
@@ -5,25 +5,46 @@ using namespace mfem;
 int main(int argc, char* argv[])
 {
     std::string config_file_path;
+    std::string device_name;
 
-    for (int i = 1; i < argc; i++)
-    {
-        // check if the argument is the -c flag
-        if (std::string(argv[i]) == "-c" && i + 1 < argc)
-        {
-            config_file_path = argv[i + 1];
-            break;
-        }
-    }
+    for (int i = 1; i < argc; ++i)
+      {
+        std::string arg = argv[i];
+        
+        if (arg == "-c")
+          {
+            if (i + 1 >= argc)
+              {
+                std::cerr << "Error: -c requires a configuration file path.\n";
+                return 1;
+              }
+            config_file_path = argv[++i];  // consume next argument
+          }
+        else if (arg == "-d")
+          {
+            if (i + 1 >= argc)
+              {
+                std::cerr << "Error: -d requires a device name.\n";
+                return 1;
+              }
+            device_name = argv[++i];  // consume next argument
+          }
+        else
+          {
+            std::cerr << "Error: Unknown argument: " << arg << "\n";
+            return 1;
+          }
+      }
 
     if (config_file_path.empty())
-    {
-        std::cerr << "\nError: Configuration file not specified." << std::endl;
-        std::cerr << "Usage: " << argv[0] << " -c <path/to/config.jason>\n" << std::endl;
+      {
+        std::cerr << "\nError: Configuration file not specified.\n";
+        std::cerr << "Usage: " << argv[0]
+                  << " -c <path/to/config.json> [-d <device>]\n\n";
         return 1;
-    }
+      }
 
-    Prandtl::Simulation &sim = Prandtl::Simulation::SimulationCreate();
+    Prandtl::Simulation &sim = Prandtl::Simulation::SimulationCreate(device_name);
     sim.LoadConfig(config_file_path);
     sim.Run();
 

--- a/scripts/run_regression_test.sh
+++ b/scripts/run_regression_test.sh
@@ -32,10 +32,15 @@ CFL=""
 DT=0.0001
 NSTEPS_OVERRIDE=0
 DT_OVERRIDE=0
+NMPIRANKS=2
+DEVICE="cpu"
+NHOSTS="1"
+
+HOST_SHORT="$(hostname -s)"
 
 usage() {
   cat <<EOF
-Usage: $0 [-n STEPS] [-b BUILDDIR] [-e EXECUTABLE] [-o RUNDIR] (-c CONFIG.json | -l LIST.txt)
+Usage: $0 [-n STEPS] [-b BUILDDIR] [-e EXECUTABLE] [-H NUMHOSTS] [-o RUNDIR] [-p NUMPROC] [-r DEVICE] (-c CONFIG.json | -l LIST.txt)
 
   -n STEPS      Number of steps to run (default: None, use case default)
   -t TIMESTEP   Fixed timestep size (default: None, use case default)
@@ -44,6 +49,10 @@ Usage: $0 [-n STEPS] [-b BUILDDIR] [-e EXECUTABLE] [-o RUNDIR] (-c CONFIG.json |
   -e EXECUTABLE Path to Prandtl executable (default: ${EXE})
   -o RUNDIR     Directory to run in (default: ${RUNDIR})
   -c CONFIG     Single example config.json to run
+  -H NHOSTS     Number of compute nodes to use (default: 1)
+  -h            Show this help message
+  -p NUMPROC    Number of MPI processes to run
+  -r DEVICE     Compute device to run on (e.g. cpu or hip, default: cpu)
   -l LIST       List file with one config.json path per line (comments (#) allowed)
 
 Examples:
@@ -53,7 +62,7 @@ EOF
 }
 
 # ---- Parse args
-while getopts ":n:t:d:b:e:o:c:l:h" opt; do
+while getopts ":n:t:d:b:e:o:p:r:c:l:H:h" opt; do
   case $opt in
       n) NSTEPS="${OPTARG}"; NSTEPS_OVERRIDE=1;;
       t) DT="${OPTARG}"; DT_OVERRIDE=1;;
@@ -61,6 +70,9 @@ while getopts ":n:t:d:b:e:o:c:l:h" opt; do
       b) BUILDDIR="${OPTARG}"; EXE="${BUILDDIR}/Prandtl";;
       e) EXE="${OPTARG}";;
       o) RUNDIR="${OPTARG}";;
+      p) NMPIRANKS="${OPTARG}";;
+      H) NHOSTS="${OPTARG}";;
+      r) DEVICE="${OPTARG}";;
       c) ONECFG="${OPTARG}";;
       l) LISTFILE="${OPTARG}";;
       h) usage; exit 0;;
@@ -110,8 +122,9 @@ run_one() {
     return 1
   fi
 
-  echo "==> Running example: ${cfg_rel}"
+  echo "==> Running example: ${cfg_rel} with ${NMPIRANKS} MPI procs."
   echo "    Working dir: ${RUNDIR}"
+  echo "    Compute device: ${DEVICE}"
 
   # Prepare per-example working area
   local exname
@@ -163,10 +176,19 @@ else
       )
   ' "${cfg_abs}" > "${patched}"
 fi
+MPI_LAUNCHER="mpiexec -n \"${NMPIRANKS}\""
+# Override MPI_LAUNCHER if required for this platform:
+case "${HOST_SHORT}" in
+    tuo*)
+        # Tuolumne@LC
+        MPI_LAUNCHER="flux run --exclusive -N \"${NHOSTS}\" -n \"${NMPIRANKS}\""
+        ;;
+esac
   # Run from the per-example dir; keep your “two levels down” invariant
   # Run example (isolate failures; do NOT exit on first error)
+  # mpiexec -n "${NMPIRANKS}" 
   set +e
-  ( cd "${work}" && mpiexec -n 2 ../Prandtl -c "${patched}" )
+  ( cd "${work}" && eval ${MPI_LAUNCHER} ../Prandtl -d "${DEVICE}" -c "${patched}" )
   local run_rc=$?
   set -e
 

--- a/src/Device/prandtl_kernels.hpp
+++ b/src/Device/prandtl_kernels.hpp
@@ -1,0 +1,101 @@
+#pragma once
+#include <cmath>
+// Drag in essential parts of MFEM for kernels
+#include "config/config.hpp"
+#include "general/forall.hpp"
+#ifndef MFEM_HOST_DEVICE
+#include "general/device.hpp"
+#endif
+#ifndef MFEM_HOST_DEVICE
+#error "MFEM_HOST_DEVICE not defined. Check MFEM headers/includes."
+#endif
+
+namespace Prandtl
+{
+
+#ifdef MFEM_USE_SINGLE
+  using real_t = float;
+#else
+  using real_t = double;
+#endif
+
+  namespace Kernels {
+    MFEM_HOST_DEVICE inline real_t rmax(real_t a, real_t b) { return a > b ? a : b; }
+    MFEM_HOST_DEVICE inline real_t rsqrt(real_t x) { return std::sqrt(x); }  // mfem::sqrt?
+    MFEM_HOST_DEVICE inline real_t rlog(real_t x)  { return std::log(x); }   // mfe::log?
+    
+    MFEM_HOST_DEVICE
+    inline void ComputeMeanVec(const real_t* a, const real_t* b, real_t* out, int n)
+    {
+      for (int i=0;i<n;++i) out[i] = real_t(0.5)*(a[i]+b[i]);
+    }
+    
+    MFEM_HOST_DEVICE
+    inline real_t ComputeLogMean(real_t x, real_t y, real_t eps) // eps defaults to 1e-4 on CPU
+    {
+      const real_t xi = y / x;
+      const real_t u  = (xi*(xi - 2.0) + 1.0) / (xi*(xi + 2.0) + 1.0);
+      
+      // polynomial approximation branch when u is small
+      if (u < eps)
+        {
+          // (x+y)*52.5 / (105 + u*(35 + u*(21 + 15*u)))
+          const real_t denom = 105.0 + u*(35.0 + u*(21.0 + 15.0*u));
+          return (x + y) * 52.5 / denom;
+        }
+      else
+        {
+          return (y - x) / Kernels::rlog(xi);
+        }
+    }
+    // Element storage: component-major (q blocks), length = dof*num_eq
+    // u[q*dof + id]
+    MFEM_HOST_DEVICE inline
+    real_t el_get(const real_t *u, int dof, int num_eq, int id, int q)
+    {
+      (void)num_eq; // not needed for this layout
+      return u[q*dof + id];
+    }
+    
+    MFEM_HOST_DEVICE inline
+    void el_gather_state(const real_t *u, const int dof, const int num_eq, const int id, real_t *dst)
+    {
+      for (int q = 0; q < num_eq; ++q)
+        dst[q] = u[q*dof + id];
+    }
+    
+    MFEM_HOST_DEVICE inline
+    void el_scatter_add(const real_t *f,
+                        const int dof,
+                        const int num_eq,
+                        const int id,
+                        const real_t scale,
+                        real_t *du)
+    {
+      // Element storage is component-major (byVDIM):
+      // du[q*dof + id] corresponds to "row id, component q" in DenseMatrix(dof, num_eq)
+      for (int q = 0; q < num_eq; ++q)
+        {
+          du[id + q*dof] += scale * f[q];
+        }
+    }
+
+    MFEM_HOST_DEVICE inline
+    void el_scale(const real_t *scale_d,
+                  const real_t fac,
+                  const int dof,      // scalar dofs per element
+                  const int neq,
+                  real_t *el_soln)        // num equations
+    {
+      for (int id = 0; id < dof; ++id)
+        {
+          const real_t invJ = fac / scale_d[id];
+          for (int q = 0; q < neq; ++q)
+            {
+              el_soln[id + q*dof] *= invJ;
+            }
+        }
+    }
+    
+  }
+}

--- a/src/Device/timer.hpp
+++ b/src/Device/timer.hpp
@@ -1,0 +1,24 @@
+// timer.hpp
+#pragma once
+#include <chrono>
+#include <cstdio>
+
+class ScopedTimer
+{
+public:
+    explicit ScopedTimer(const char* name)
+        : name_(name),
+          start_(clock::now()) {}
+
+    ~ScopedTimer()
+    {
+        auto end = clock::now();
+        double ms = std::chrono::duration<double, std::milli>(end - start_).count();
+        std::printf("[TIMER] %s : %.6f ms\n", name_, ms);
+    }
+
+private:
+    using clock = std::chrono::steady_clock;
+    const char* name_;
+    clock::time_point start_;
+};

--- a/src/Physics/GasModel.hpp
+++ b/src/Physics/GasModel.hpp
@@ -19,17 +19,19 @@ namespace Prandtl
     StateLayout L;
     EOSImpl eos;
     TransportImpl transport;
-    
+
+    MFEM_HOST_DEVICE GasModel() = default;
+
     MFEM_HOST_DEVICE
     GasModel(const PhysicsConstants &phys_in, const StateLayout &L_in,
              const EOSImpl &eos_in, const TransportImpl &tr_in)
       : phys(phys_in), L(L_in), eos(eos_in), transport(tr_in)
-    { }
+    { };
 
     MFEM_HOST_DEVICE
     GasModel(const PhysicsConstants &phys_in, const StateLayout &L_in)
       : phys(phys_in), L(L_in)
-    { }
+    { };
 
     // Utilities and constants etc
     MFEM_HOST_DEVICE
@@ -41,36 +43,36 @@ namespace Prandtl
     { return L.dim; };
 
     // State Access
-    MFEM_HOST_DEVICE
     template<typename StateView>
+    MFEM_HOST_DEVICE
     inline real_t velocity(const StateView &S, int d) const
-    { return S.velocity(L,d);}
+    { return S.velocity(L,d);};
 
-    MFEM_HOST_DEVICE
     template<typename StateView>
+    MFEM_HOST_DEVICE
     inline real_t momentum(const StateView &S, int d) const
-    { return S.momentum(L,d);}
+    { return S.momentum(L,d);};
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t density(const StateView &S) const
     {
       return eos.density(phys, L, S);
-    }
+    };
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t mass(const StateView &S) const
     {
       return eos.density(phys, L, S);
-    }
+    };
 
     template<typename StateView>
     MFEM_HOST_DEVICE
     inline real_t energy(const StateView &S) const
     {
       return S.energy(L);
-    }
+    };
 
     // --- Thermodynamics ------------------------------------------------------
     template<typename StateView>

--- a/src/Physics/GasState.hpp
+++ b/src/Physics/GasState.hpp
@@ -20,7 +20,7 @@
 //
 // Each block has length = num_dofs_scalar (wrt mesh or element)
 //
-#include "Kernels.hpp"
+#include "prandtl_kernels.hpp"
 
 namespace Prandtl
 {
@@ -43,6 +43,7 @@ namespace Prandtl
     int eq_scalar0;       // index of first scalar component (or -1 if none)
     int num_scalars;      // number of scalar components
     
+    MFEM_HOST_DEVICE StateLayout() = default;
     /**
      * Set up after creation.
      *
@@ -121,7 +122,7 @@ namespace Prandtl
   {
     const real_t* U;           // packed state data -> [rho, rhoVx, rhoVy, ..., rhoE]
     
-    PointStateView(const real_t* U_)
+    MFEM_HOST_DEVICE explicit PointStateView(const real_t* U_)
       : U(U_)
     { }
 

--- a/src/Physics/Physics.hpp
+++ b/src/Physics/Physics.hpp
@@ -1,26 +1,28 @@
 #pragma once
 
-#include "Kernels.hpp"
+#include "prandtl_kernels.hpp"
 
 namespace Prandtl
 {
 
   struct PhysicsConstants
   {
-    const real_t gamma;
-    const real_t gammaInverse;
-    const real_t gammaP1;
-    const real_t gammaM1;
-    const real_t gammaP1Inverse;
-    const real_t gammaM1Inverse;
-    const real_t gamma_gammaM1Inverse; // gamma * gammaM1Inverse;
-    const real_t gammaM1_gammaInverse; // gammaM1 * gammaInverse;
+    real_t gamma;
+    real_t gammaInverse;
+    real_t gammaP1;
+    real_t gammaM1;
+    real_t gammaP1Inverse;
+    real_t gammaM1Inverse;
+    real_t gamma_gammaM1Inverse; // gamma * gammaM1Inverse;
+    real_t gammaM1_gammaInverse; // gammaM1 * gammaInverse;
 
-    const real_t Pr;
-    const real_t PrInverse;
-    const real_t R_gas;
-    const real_t cp;
-    const real_t mu;
+    real_t Pr;
+    real_t PrInverse;
+    real_t R_gas;
+    real_t cp;
+    real_t mu;
+
+    MFEM_HOST_DEVICE PhysicsConstants() = default;
 
     PhysicsConstants(real_t gamma, real_t Pr, real_t R_gas, real_t mu)
       : gamma(gamma), Pr(Pr), R_gas(R_gas), mu(mu),
@@ -29,10 +31,10 @@ namespace Prandtl
         gammaM1_gammaInverse(gammaM1 * gammaInverse), gamma_gammaM1Inverse(gamma * gammaM1Inverse),
         PrInverse(1.0 / Pr), cp(gamma_gammaM1Inverse * R_gas) {}
 
-    const real_t mu_bulk = 2.0 / 3.0;
-    const real_t mu0 = 1.716e-5;
-    const real_t T0 = 273.15;
-    const real_t Ts = 110.4;
+    real_t mu_bulk = 2.0 / 3.0;
+    real_t mu0 = 1.716e-5;
+    real_t T0 = 273.15;
+    real_t Ts = 110.4;
 };
 
 // extern const real_t gamma;

--- a/src/Simulation/Simulation.cpp
+++ b/src/Simulation/Simulation.cpp
@@ -28,24 +28,34 @@
 #include "json.hpp"
 #include <filesystem>
 #include <mpi.h>
-
 namespace Prandtl
 {
 
-Simulation& Simulation::SimulationCreate()
+  Simulation& Simulation::SimulationCreate(std::string device_cfg)
 {
-    static Simulation sim;
-    return sim;
+  static Simulation sim(device_cfg);
+  return sim;
 }
 
-Simulation::Simulation()
+  void Simulation::InitDevice(std::string device_cfg)
+  {
+    if(device_cfg.empty()){
+      device_cfg = "cpu";
+    }
+    if(!device_){
+      device_ = std::make_unique<mfem::Device>(device_cfg);
+      if(myRank == 0){ device_->Print(); }
+    }
+  }
+
+  Simulation::Simulation(std::string device_cfg)
     : r_coef([](const Vector &X){ return X[1];}), z_coef([](const Vector &X){ return X[0];})
 {
     Mpi::Init();
     numProcs = Mpi::WorldSize();
     myRank = Mpi::WorldRank();
     Hypre::Init();
-
+    InitDevice(device_cfg);
 
     if (Mpi::Root())
     {
@@ -274,15 +284,18 @@ void Simulation::LoadConfig(const std::string &config_file_path)
         mesh->bdr_attribute_sets.SetAttributeSet("left", left);
         mesh->bdr_attribute_sets.SetAttributeSet("right", right);
     }
-
+    if (!periodic && mesh->GetNBE() == 0){
+      mesh->GenerateBoundaryElements();
+    }
     if (runtime.contains("ser_ref_levels"))
-    {
+      {
         ref_levels = runtime.value("ser_ref_levels", 0);
         for (int lev = 0; lev < ref_levels; lev++)
         {
             mesh->UniformRefinement();
         }
     }
+    mesh->FinalizeTopology();
 
     if (mesh->GetNE() < Mpi::WorldSize())
     {
@@ -303,11 +316,14 @@ void Simulation::LoadConfig(const std::string &config_file_path)
         mesh->ReorderElements(mesh_ordering);
     }
 
-    if (dim > 1)
-    {
+    // TODO: Let's gate this for now
+    if (dim > 1 && runtime.value("use_nc_mesh", true))
+      {
         mesh->EnsureNCMesh();
-    }
+      }
 
+    // Completely finalize the mesh
+    mesh->FinalizeMesh(0, true);
     pmesh = std::make_shared<ParMesh>(MPI_COMM_WORLD, *mesh);
     mesh->Clear();
 
@@ -320,12 +336,20 @@ void Simulation::LoadConfig(const std::string &config_file_path)
         }
     }
 
-    fec = std::make_shared<DG_FECollection>(order, dim, btype);
+    pmesh->ExchangeFaceNbrData();
     fec0 = std::make_shared<DG_FECollection>(0, dim);
-    vfes = std::make_shared<ParFiniteElementSpace>(pmesh.get(), fec.get(), num_equations, ordering);
     fes0 = std::make_shared<ParFiniteElementSpace>(pmesh.get(), fec0.get());
+
+    fec = std::make_shared<DG_FECollection>(order, dim, btype);
+    vfes = std::make_shared<ParFiniteElementSpace>(pmesh.get(), fec.get(), num_equations, ordering);
     dfes = std::make_unique<ParFiniteElementSpace>(pmesh.get(), fec.get(), dim, ordering);
     fes = std::make_unique<ParFiniteElementSpace>(pmesh.get(), fec.get());
+
+    // Let's do an initial exchange to get the data structures populated
+    vfes->ExchangeFaceNbrData();
+    fes0->ExchangeFaceNbrData();
+    dfes->ExchangeFaceNbrData();
+    fes->ExchangeFaceNbrData();
 
     num_dofs_scalar = fes->GetNDofs();
     num_dofs_system = vfes->GetVSize();
@@ -477,6 +501,7 @@ void Simulation::LoadConfig(const std::string &config_file_path)
     {
         alpha_max = 0.5;
     }
+
     auto integrator =
       std::make_unique<Prandtl::DGSEMIntegrator>(pmesh, fes0, alpha, liftingScheme, *numericalFlux, order+1);
 
@@ -857,7 +882,9 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                 }
             }
             pd->RegisterField("Pressure", p.get());
+#ifdef SUBCELL_FV_BLENDING
             pd->RegisterField("Blending Coeff", alpha.get());
+#endif
             pd->SetLevelsOfDetail(order);
             pd->SetDataFormat(VTKFormat::BINARY);
             pd->SetHighOrderOutput(true);
@@ -884,7 +911,9 @@ void Simulation::LoadConfig(const std::string &config_file_path)
                 }
             }
             vd->RegisterField("Pressure", p.get());
+#ifdef SUBCELL_FV_BLENDING
             vd->RegisterField("Blending Coeff", alpha.get());
+#endif
         }
     }
 }
@@ -982,7 +1011,7 @@ void Simulation::Run()
 
         
 #else
-        real_t *sol_state = sol->GetData();
+        const real_t *sol_state = sol->HostRead();
         for (int i = 0; i < num_dofs_scalar; i++)
           {
             Prandtl::DofStateView dofState{sol_state, i};
@@ -1065,7 +1094,7 @@ void Simulation::Run()
         NS->RecoverStateFromWeighted(*sol, U_cons);
         ConservativeToPrimitive(U_cons, *rho_axi, *u, *v, *p);
 #else
-        real_t *sol_state = sol->GetData();
+        const real_t *sol_state = sol->HostRead();
         for (int i = 0; i < num_dofs_scalar; i++)
         {       
           Prandtl::DofStateView dofState{sol_state, i};

--- a/src/Simulation/Simulation.hpp
+++ b/src/Simulation/Simulation.hpp
@@ -107,7 +107,9 @@ private:
   std::vector<Array<int>> bdr_marker_vector;
   Array<int> set_marker;
   int max_bdr_attr;
-  
+  void InitDevice(std::string);
+  std::unique_ptr<mfem::Device> device_;
+
 #ifdef AXISYMMETRIC
   void ConservativeToPrimitive(const Vector &U_cons,
                                ParGridFunction &rho_out,
@@ -116,12 +118,12 @@ private:
                                ParGridFunction &p_out) const;  
 #endif
   
-  Simulation();
+  Simulation(std::string);
   
   // change some shared_ptrs to unique_ptrs
   
 public:    
-  static Simulation& SimulationCreate();
+  static Simulation& SimulationCreate(std::string);
   void LoadConfig(const std::string &config_file_path);
   
   ~Simulation();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,12 +28,10 @@ add_executable(gas_tests
    transport_tests.cpp
    gas_model_tests.cpp
 )
+
 target_include_directories(gas_tests
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/mfem
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/hypre/src/hypre/include
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/metis-5.1.0/include
-    ${PROJECT_SOURCE_DIR}/src/Physics
-    ${PROJECT_SOURCE_DIR}/src/Device
+    PRIVATE ${PROJECT_SOURCE_DIR}/src/Physics
+    PRIVATE ${PROJECT_SOURCE_DIR}/src/Device
 )
 
 # Propagate SUTHERLAND compile definition to gas_tests if enabled
@@ -41,14 +39,7 @@ if(SUTHERLAND)
     target_compile_definitions(gas_tests PRIVATE SUTHERLAND)
 endif()
 
-target_link_directories(gas_tests
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/mfem
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/hypre/src/lib
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/metis-5.1.0/lib
-)
-target_link_libraries(gas_tests
-    mfem HYPRE metis MPI::MPI_CXX
-)
+target_link_libraries(gas_tests PRIVATE ${PRANDTL_MFEM_TARGET})
 
 add_test(NAME GasPhysicsTestingSuite COMMAND gas_tests)
 
@@ -59,20 +50,10 @@ add_executable(state_tests
 )
 
 target_include_directories(state_tests
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/mfem
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/hypre/src/hypre/include
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/metis-5.1.0/include
-    ${PROJECT_SOURCE_DIR}/src/Physics
-    ${PROJECT_SOURCE_DIR}/src/Device
+    PRIVATE ${PROJECT_SOURCE_DIR}/src/Physics
+    PRIVATE ${PROJECT_SOURCE_DIR}/src/Device
 )
 
-target_link_directories(state_tests
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/mfem
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/hypre/src/lib
-    PUBLIC ${PROJECT_SOURCE_DIR}/libs/metis-5.1.0/lib
-)
-target_link_libraries(state_tests
-    mfem HYPRE metis MPI::MPI_CXX
-)
+target_link_libraries(state_tests PRIVATE ${PRANDTL_MFEM_TARGET})
 
 add_test(NAME StateTestingSuite COMMAND state_tests)


### PR DESCRIPTION
## Pull request overview

This PR adds MFEM device-ready infrastructure to the Prandtl simulation framework, enabling GPU/accelerator support. It refactors the build system to use MFEM's CMake config package instead of hardcoded library paths, introduces device initialization via `mfem::Device`, adds device-compatible state layout views, and updates data access patterns to be device-aware.

**Changes:**
- Refactored CMake build system to use `find_package(MFEM)` and propagate the MFEM target, removing hardcoded library paths for mfem/hypre/metis.
- Added `mfem::Device` initialization infrastructure in `Simulation`, new `StateLayout.hpp` with host/device-annotated state views, and `prandtl_kernels.hpp` for device-portable math utilities.
- Updated `main.cpp` to accept a `-d` device argument, updated data access to use `HostRead()` for device safety, and added regression test script support for device/MPI configuration.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| CMakeLists.txt | Switch to `find_package(MFEM)`, add sanitizer/debug options, remove hardcoded lib paths |
| tests/CMakeLists.txt | Simplify test targets to use `PRANDTL_MFEM_TARGET` |
| main.cpp | Add `-d` device argument parsing, pass to `SimulationCreate` |
| src/Simulation/Simulation.hpp | Add `InitDevice` method, `device_` member, update constructor/factory signatures |
| src/Simulation/Simulation.cpp | Implement `InitDevice`, mesh finalization improvements, device-safe data access |
| src/Physics/StateLayout.hpp | New file with device-annotated state layout and view structs |
| src/Physics/Physics.hpp | Remove `const` from `PhysicsConstants` fields, add default constructor |
| src/Physics/GasState.hpp | Add `MFEM_HOST_DEVICE` annotations |
| src/Physics/GasModel.hpp | Add default constructor, reorder template/attribute annotations |
| src/Device/prandtl_kernels.hpp | New file with device-portable kernel helpers |
| src/Device/timer.hpp | New scoped timer utility |
| scripts/run_regression_test.sh | Add MPI rank count, device, and host options |
| .github/workflows/ci-quick.yml | Comment out CONFIG_FILE usage |
| libs/mfem | Update MFEM submodule commit |
</details>

#### copilot-generated