### PR TITLE
Cache operator data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ endif()
 option(NO_OPT "Disable optimizations for testing" OFF)
 
 if (NO_OPT AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
-  message(STATUS "Disabling all optimizations on target: myexe")
+  message(STATUS "Disabling all optimizations on target: ${PROJECT_NAME}")
 
   # Compile flags
   target_compile_options(${PROJECT_NAME} PRIVATE

--- a/src/Integrators/DGSEMIntegrator/DGSEMIntegrator.hpp
+++ b/src/Integrators/DGSEMIntegrator/DGSEMIntegrator.hpp
@@ -3,6 +3,8 @@
 #include "mfem.hpp"
 #include "NumericalFlux.hpp"
 #include "LiftingScheme.hpp"
+#include "ChandrashekarFlux.hpp"
+#include "dgsem_cache.hpp"
 
 namespace Prandtl
 {
@@ -57,6 +59,7 @@ private:
     Vector el_dudxi, el_dudeta, el_dudzeta;
 
     std::shared_ptr<LiftingScheme> liftingScheme;
+  DGSEMOperatorCache *operator_cache = nullptr;
 
     void ComputeSubcellMetrics();
     void ComputeFVFluxes(const DenseMatrix &el_u_mat, real_t alpha_value, ElementTransformation &Tr, DenseMatrix &el_dudt_mat);
@@ -65,7 +68,8 @@ private:
 #endif
 
 public:
-
+  void SetOperatorCache(DGSEMOperatorCache *cache_)
+  { operator_cache = cache_; };
     inline real_t GetMaxCharSpeed()
     {
         return max_char_speed;

--- a/src/Operators/DGSEMOperator.cpp
+++ b/src/Operators/DGSEMOperator.cpp
@@ -2,82 +2,102 @@
 
 namespace Prandtl
 {
-DGSEMOperator::DGSEMOperator(std::shared_ptr<ParFiniteElementSpace> vfes_,
-                             std::shared_ptr<ParFiniteElementSpace> fes0_,
-                             std::shared_ptr<ParMesh> pmesh_,
-                             std::shared_ptr<ParGridFunction> eta_,
-                             std::shared_ptr<ParGridFunction> alpha_,
-                             std::vector<std::shared_ptr<ParGridFunction> > &grad_u_,
-                             std::unique_ptr<DGSEMIntegrator> integrator_,
-                             std::unique_ptr<Indicator> indicator_,
-                             const IdealGasModel &gasModel_,
-                             std::shared_ptr<ParGridFunction> r_gf_,
-                             const real_t alpha_max, const real_t alpha_min)
-                             : TimeDependentOperator(vfes_->GetTrueVSize()),
-                             vfes(vfes_), fes0(fes0_), pmesh(pmesh_),
-                               eta(eta_), alpha(alpha_), grad_u(grad_u_),
-                             integrator(std::move(integrator_)), indicator(std::move(indicator_)),
-                             gasModel(gasModel_),
-                             num_equations(vfes->GetVDim()), dim(pmesh->SpaceDimension()),
-                             order(vfes->GetElementOrder(0)), num_elements(pmesh->GetNE()),
-                             Ndofs(vfes->GetFE(0)->GetDof()),
-                             modalThreshold(0.5 * std::pow(10.0, -1.8 * std::pow(order, 0.25))),
-                             r_gf(r_gf_), alpha_max(alpha_max), alpha_min(alpha_min),
-                             num_dofs_scalar(vfes_->GetTrueVSize()/vfes_->GetVDim())
-                             #ifdef AXISYMMETRIC
-                             , U(vfes->GetTrueVSize())
-                             #endif
-{
+  DGSEMOperator::DGSEMOperator(std::shared_ptr<ParFiniteElementSpace> vfes_,
+                               std::shared_ptr<ParFiniteElementSpace> fes0_,
+                               std::shared_ptr<ParMesh> pmesh_,
+                               std::shared_ptr<ParGridFunction> eta_,
+                               std::shared_ptr<ParGridFunction> alpha_,
+                               std::vector<std::shared_ptr<ParGridFunction> > &grad_u_,
+                               std::unique_ptr<DGSEMIntegrator> integrator_,
+                               std::unique_ptr<Indicator> indicator_,
+                               const IdealGasModel &gasModel_,
+                               std::shared_ptr<ParGridFunction> r_gf_,
+                               const real_t alpha_max, const real_t alpha_min)
+  : TimeDependentOperator(vfes_->GetTrueVSize()),
+    vfes(vfes_), fes0(fes0_), pmesh(pmesh_),
+    eta(eta_), alpha(alpha_), grad_u(grad_u_),
+    integrator(std::move(integrator_)), indicator(std::move(indicator_)),
+    gasModel(gasModel_),
+    num_equations(vfes->GetVDim()), dim(pmesh->SpaceDimension()),
+    order(vfes->GetElementOrder(0)), num_elements(pmesh->GetNE()),
+    Ndofs(vfes->GetFE(0)->GetDof()),
+    modalThreshold(0.5 * std::pow(10.0, -1.8 * std::pow(order, 0.25))),
+    r_gf(r_gf_), alpha_max(alpha_max), alpha_min(alpha_min),
+    num_dofs_scalar(vfes_->GetTrueVSize()/vfes_->GetVDim())
+#ifdef AXISYMMETRIC
+  , U(vfes->GetTrueVSize())
+#endif
+  {
     nonlinearForm.reset(new DGSEMNonlinearForm(vfes.get()));
-
+    
     nonlinearForm->AddDomainIntegrator(integrator.get());
     nonlinearForm->AddInteriorFaceIntegrator(integrator.get());
-
+    
     std::vector<BdrFaceIntegrator*>::iterator it1 = bfnfi.begin();
     std::vector<Array<int>>::iterator it2 = bdr_marker.begin();
-
+    
     for (; it1 != bfnfi.end() && it2 != bdr_marker.end(); ++it1, ++it2)
-    {
+      {
         nonlinearForm->AddBdrFaceIntegrator(*it1, *it2);
-    }
+      }
     nonlinearForm->UseExternalIntegrators();
-
+    
 #ifdef PARABOLIC
     global_entropy.SetSize(vfes->GetVSize());
 #endif
-}
+    
+    CreateOperatorCache();
+    AssembleDeviceCache();
+    nonlinearForm->SetOperatorCache(&operator_cache);
+    integrator->SetOperatorCache(&operator_cache);
+  }
+  
+  void DGSEMOperator::CreateOperatorCache()
+  {
+    GetDiscretizationInfo(vfes.get(), &operator_cache);
+    SetupRestrictions(vfes.get(), &operator_cache);
+    SetupVolumeMarkers(vfes.get(), &operator_cache);
+    SetupGeometricTerms(vfes.get(), &operator_cache);
+    // Important that gasModel is POD for host<->device
+    operator_cache.gas = gasModel;
+  }
 
-DGSEMOperator::~DGSEMOperator()
-{
+  void DGSEMOperator::AssembleDeviceCache()
+  {
+    GetDeviceCache(operator_cache, device_cache);
+  }
+  
+  DGSEMOperator::~DGSEMOperator()
+  {
     for (auto ptr : bfnfi)
-    {
+      {
         delete ptr;
-    }
-}
-
-void DGSEMOperator::ComputeBlendingCoefficient(const Vector &x) const
-{
+      }
+  }
+  
+  void DGSEMOperator::ComputeBlendingCoefficient(const Vector &x) const
+  {
     indicator->CheckSmoothness(x);
     for (int el = 0; el < num_elements; el++)
-    {
+      {
         fes0->GetElementDofs(el, ind_indx);
         eta->GetSubVector(ind_indx, ind_dof);
         alpha_dof = 1.0 / (1.0 + std::exp(-sharpness_fac * (ind_dof(0) - modalThreshold) / modalThreshold));
         if (alpha_dof < alpha_min)
-        {
+          {
             alpha_dof = 0.0;
-        }
+          }
         else if (alpha_dof > (1.0 - alpha_min))
-        {
+          {
             alpha_dof = 1.0;
-        }
+          }
         alpha_dof = std::min(alpha_dof, alpha_max);
         alpha->SetSubVector(ind_indx, alpha_dof);
-    }
+      }
     
-}
-
-void DGSEMOperator::ComputeGlobalEntropyVector(const Vector &u, Vector &global_entropy) const
+  }
+  
+  void DGSEMOperator::ComputeGlobalEntropyVector(const Vector &u, Vector &global_entropy) const
 {
     DenseMatrix ent_mat(Ndofs, num_equations);
     for (int el = 0; el < num_elements; el++)
@@ -500,7 +520,7 @@ void DGSEMOperator::ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &du
                 const IntegrationPoint &ip = nodes.IntPoint(ld);
                 Vector X(dim);
                 Tr.Transform(ip, X);
-                const double r = (dim > 1) ? X(1) : 0.0;
+                const real_t r = (dim > 1) ? X(1) : 0.0;
 
                 if (std::abs(r) <= 1e-14)
                 {
@@ -585,6 +605,7 @@ void DGSEMOperator::Mult(const Vector &u, Vector &dudt) const
         max_char_speed = std::max(bfnfi[b]->GetMaxCharSpeed(), max_char_speed);
     }
 #endif
+
 }
 
 void DGSEMOperator::AddBdrFaceIntegrator(BdrFaceIntegrator *bfi, Array<int> &bdr_marker)

--- a/src/Operators/DGSEMOperator.hpp
+++ b/src/Operators/DGSEMOperator.hpp
@@ -7,12 +7,13 @@
 #include "Indicator.hpp"
 #include "BasicOperations.hpp"
 #include "GasModel.hpp"
+#include "dgsem_cache_utilities.hpp"
 
 namespace Prandtl
 {
 
 using namespace mfem;
-
+  
 class DGSEMOperator : public TimeDependentOperator
 {
 private:
@@ -61,12 +62,16 @@ private:
     mutable Array<int> ind_indx;
     mutable Vector ind_dof;
     mutable real_t alpha_dof;
+    DGSEMOperatorCache operator_cache;
+    DGSEMDeviceCache device_cache;
 
+    void CreateOperatorCache();
     void ComputeGlobalEntropyVector(const Vector &u, Vector &global_entropy) const;
     void ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &dudx) const;
     void ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &dudx, Vector &dudy) const;
     void ComputeGlobalPrimitiveGradVector(const Vector &u, Vector &dudx, Vector &dudy, Vector &dudz) const;
     void ComputeBlendingCoefficient(const Vector &u) const;
+    void AssembleDeviceCache();
 
 #ifdef AXISYMMETRIC
     void BuildAxisIndexFromMarker();
@@ -133,7 +138,6 @@ public:
         p_floor_abs = std::max(p_floor_abs, p_fac * p_inf);
     }
 #endif
-
 };
 
 }

--- a/src/Operators/NonlinearForm/DGSEMNonlinearForm.hpp
+++ b/src/Operators/NonlinearForm/DGSEMNonlinearForm.hpp
@@ -3,7 +3,9 @@
 #include "mfem.hpp"
 #include "DGSEMIntegrator.hpp"
 #include "BdrFaceIntegrator.hpp"
-#include "../../../libs/mfem/general/forall.hpp"
+#include "timer.hpp"
+#include "general/forall.hpp"
+#include "dgsem_cache_utilities.hpp"
 
 namespace Prandtl
 {
@@ -17,8 +19,13 @@ private:
     Array<DGSEMIntegrator*> dnfi, fnfi;
     Array<BdrFaceIntegrator*> bfnfi;
     mutable ParGridFunction GRAD_X, GRAD_Y, GRAD_Z;
+    Prandtl::DGSEMOperatorCache *cache = nullptr;
+
 public:
     DGSEMNonlinearForm(ParFiniteElementSpace *pfes);
+    void SetOperatorCache(DGSEMOperatorCache *cache_){
+      cache = cache_;
+    }
     void MultLifting(const Vector &u, Vector &dudx, Vector &dudy, Vector &dudz) const;
     void MultLifting(const Vector &u, Vector &dudx, Vector &dudy) const;
     void MultLifting(const Vector &u, Vector &dudx) const;

--- a/src/Operators/dgsem_cache.hpp
+++ b/src/Operators/dgsem_cache.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "mfem.hpp"
+#include "GasModel.hpp"
+#include "ChandrashekarFlux.hpp"
+
+namespace Prandtl
+{
+    struct DGSEMOperatorCache {
+      // constants needed by kernels
+      int p = 0;
+      int dim = 0;
+      int Np = 0;
+      int Np_x = 0;
+      int Np_y = 0;
+      int Np_z = 0;
+      int num_attr = 0;
+      int num_elements = 0;
+      int num_equations = 0;
+      int ndof_scalar_el = 0;
+      int num_face_points = 0;
+      int num_interior_faces = 0;
+
+      // Host Only: Integration rules, operators, restrictions 
+      mfem::IntegrationRules GLIntRules{0, mfem::Quadrature1D::GaussLobatto};
+      const mfem::IntegrationRule *ir = nullptr;
+      const mfem::IntegrationRule *ir_face = nullptr;
+      const mfem::IntegrationRule *ir_vol = nullptr;
+      const mfem::ElementRestrictionOperator *restr_v = nullptr; // for volume vfes
+      const mfem::FaceRestriction *restr_f = nullptr; // for face vfes (vector space)
+      std::unique_ptr<mfem::FaceQuadratureSpace> fqs_int; // interior faces perm
+
+      // Aux data for preprocessing
+      mfem::Array<int> inv_fp_map;
+
+      // Data arrays for use on device
+      mfem::Array<int> elem_attr;    // size ne, values are 1-based attributes
+      mfem::Array<int> vol_attr_marker;  // size nattr, 0/1
+      mfem::Array<int> domain_attr_marker;  // size nattr, 0/1
+      mfem::Vector elJac;
+      mfem::Vector elMetric;
+      mfem::Vector D;
+      mfem::Vector Dhat;
+      mfem::Vector Dhat2;
+      mfem::Vector face_normals;
+      mfem::Vector face_wt_minus;
+      mfem::Vector face_wt_plus;
+
+      // Physics parts - used directly on device
+      mutable mfem::Vector elWaveSpeed; // size nelements
+      mutable mfem::Vector ifWaveSpeed; // size ninterior faces
+      mutable mfem::Vector bndWaveSpeed; // size nbnd faces
+      Prandtl::IdealGasModel gas;
+      Prandtl::ChandrashekarFlux::InviscidFlux iflux;
+
+      // Grab the face dof from the restriction (face,point) index
+      // This answers: what is the facial dof that corresponds to
+      // the facial point index for a given face in the restriction?
+      int MapFp(int face_slot, int fp_restr) const
+      {
+        return fqs_int->GetPermutedIndex(face_slot, fp_restr);
+      }
+      // And the inverse mapping
+      int MapFpInv(int face_slot, int fp_perm) const {
+        return inv_fp_map[face_slot*num_face_points + fp_perm];
+      }
+    };
+
+  struct DGSEMDeviceCache {
+    int p = 0;
+    int dim = 0;
+    int num_elements = 0;
+    int ndof_scalar_el = 0;
+    int num_equations = 0;
+    int num_face_points = 0;
+    int num_interior_faces = 0;
+    int Np_x = 0;
+    int Np_y = 0;
+    int Np_z = 0;
+    int Np = 0;
+    int num_attr = 0;
+    const int *elem_attr_d = nullptr;    // size ne, values are 1-based attributes
+    const int *attr_marker_d = nullptr;  // size nattr, 0/1
+    const real_t *elJac_d = nullptr;
+    const real_t *elMetric_d = nullptr;
+    const real_t *D_d = nullptr;
+    const real_t *Dhat_d = nullptr;
+    const real_t *Dhat2_d = nullptr;
+    const real_t *nor_d = nullptr;
+    const real_t *fw_minus_d = nullptr;
+    const real_t *fw_plus_d = nullptr;
+
+    // Physics parts
+    real_t *elWaveSpeed_d = nullptr;
+    real_t *ifWaveSpeed_d = nullptr;
+    real_t *bndWaveSpeed_d = nullptr;
+    Prandtl::IdealGasModel gas;
+    Prandtl::ChandrashekarFlux::InviscidFlux iflux;
+
+
+    MFEM_HOST_DEVICE inline int iface_idx(int side, int fp, int eq) const
+    {
+      return ((side*num_equations + eq)*num_face_points + fp);
+    }
+    MFEM_HOST_DEVICE inline int iface_size() const
+    {
+      return 2*num_equations*num_face_points;
+    }
+  };
+}

--- a/src/Operators/dgsem_cache_utilities.hpp
+++ b/src/Operators/dgsem_cache_utilities.hpp
@@ -1,0 +1,457 @@
+#pragma once
+#include "mfem.hpp"
+#include "dgsem_cache.hpp"
+
+namespace Prandtl {
+
+  template<typename CacheT>
+  void GetOperatorCache(mfem::FiniteElementSpace *fes, CacheT *cache)
+  {
+    GetDiscretizationInfo(fes, cache);
+    SetupRestrictions(fes, cache);
+    SetupVolumeMarkers(fes, cache);
+    SetupGeometricTerms(fes, cache);
+ 
+    // TODO: Move these to where the caches are created and validated
+    // MFEM_VERIFY(nfaces == cache.num_interior_faces, "restriction faces != cached interior faces");
+    // MFEM_VERIFY(cache.face_normals.Size() == nfaces*nfp*dim, "normals size mismatch");
+    // MFEM_VERIFY(cache.face_wt_minus.Size() == nfaces*nfp, "w_minus size mismatch");
+    // MFEM_VERIFY(cache.face_wt_plus.Size()  == nfaces*nfp, "w_plus size mismatch");
+  }
+
+  template<typename GasModelT, typename DeviceCacheT>
+  void SetupGasModel(GasModelT &gas_model, DeviceCacheT &device_cache)
+  {
+    device_cache.gas = gas_model;
+  }
+
+  template<typename CacheT>
+  void GetDiscretizationInfo(mfem::FiniteElementSpace *fes, CacheT *cache)
+  {
+
+    MFEM_VERIFY(fes, "fes must be set");
+    mfem::Mesh *mesh = fes->GetMesh();
+    MFEM_VERIFY(mesh, "mesh must be set");
+    const int p = fes->GetFE(0)->GetOrder();
+    const int dim = mesh->SpaceDimension();
+    const int Np = p + 1; // num 1d quadrature points
+    const int Np_x = Np;
+    const int Np_y = dim > 1 ? Np : 1;
+    const int Np_z = dim > 2 ? Np : 1;
+    const int ne = fes->GetNE();
+    const int num_dofs_per_eqn_per_element = fes->GetFE(0)->GetDof();
+    const int num_eqns = fes->GetVDim();
+
+    cache->p = p;
+    cache->Np = Np;
+    cache->dim = dim;
+    cache->Np_x = Np_x;
+    cache->Np_y = Np_y;
+    cache->Np_z = Np_z;
+    cache->num_elements = ne;
+    cache->ndof_scalar_el = num_dofs_per_eqn_per_element;
+    cache->num_equations = num_eqns;
+  }
+
+  template<typename CacheT>
+  void SetupRestrictions(mfem::FiniteElementSpace *fes, CacheT *cache)
+  {
+    auto *pfes = dynamic_cast<mfem::ParFiniteElementSpace*>(fes);
+    MFEM_VERIFY(pfes, "Restriction setup requires ParFiniteElementSpace");
+    cache->restr_v = fes->GetElementRestriction(mfem::ElementDofOrdering::LEXICOGRAPHIC);
+    cache->restr_f = pfes->GetFaceRestriction(mfem::ElementDofOrdering::LEXICOGRAPHIC,
+                                              mfem::FaceType::Interior,
+                                              mfem::L2FaceValues::DoubleValued);
+  }
+
+  // Set up and populate elJac, elMetric, D, Dhat, Dhat2
+  // Face normals, and weights
+  template<typename CacheT>
+  void SetupGeometricTerms(mfem::FiniteElementSpace *fes, CacheT *cache)
+  {
+    const int nelem = cache->num_elements;
+    const int p = cache->p;
+    const int Np = cache->Np;
+    const int dim = cache->dim;
+    const int Np_x = Np;
+    const int Np_y = dim > 1 ? Np : 1;
+    const int Np_z = dim > 2 ? Np : 1;
+    const int neq = cache->num_equations;
+    mfem::Mesh *mesh = fes->GetMesh();
+
+    // Build integration rules
+    const int IntegrationOrder = 2 * Np_x - 3;
+    cache->ir = &cache->GLIntRules.Get(mfem::Geometry::SEGMENT, IntegrationOrder);
+    auto vol_topo = (dim == 1 ? mfem::Geometry::SEGMENT :
+                     (dim == 2 ? mfem::Geometry::SQUARE : mfem::Geometry::CUBE));
+    auto face_topo = (dim == 1 ? mfem::Geometry::POINT :
+                      (dim == 2 ? mfem::Geometry::SEGMENT : mfem::Geometry::SQUARE));
+
+    cache->ir_face = &cache->GLIntRules.Get(face_topo, IntegrationOrder);
+    cache->ir_vol = &cache->GLIntRules.Get(vol_topo, IntegrationOrder);
+
+    MFEM_ASSERT(cache->ir->GetNPoints() == Np_x, "");
+    MFEM_ASSERT(cache->ir_vol->GetNPoints() == Np_x*Np_y*Np_z, "");
+
+    // Populate element Jacobian determinant and metric terms
+    cache->elJac.SetSize(Np_x*Np_y*Np_z*nelem);
+    cache->elMetric.SetSize(dim*dim*Np_x*Np_y*Np_z*nelem);
+    for (int i = 0; i < nelem; i++)
+      {
+        mfem::ElementTransformation *T = fes->GetElementTransformation(i);
+        assert(T->ElementNo == i);
+        AssembleElementVolumeGeometricTerms(*T, cache);
+      }
+
+    // Set up derivative operators
+    mfem::DenseMatrix D_T, Dhat_T, Dhat2_T;
+    D_T.SetSize(Np_x);
+    Dhat_T.SetSize(Np_x);
+    Dhat2_T.SetSize(Np_x);
+
+    mfem::Vector wBary(Np_x);
+    wBary = 1.0;
+
+    for (int i = 1; i < Np_x; i++)
+      {
+        for (int j = 0; j < i; j++)
+          {
+            wBary(j) *= (cache->ir->IntPoint(j).x - cache->ir->IntPoint(i).x);
+            wBary(i) *= (cache->ir->IntPoint(i).x - cache->ir->IntPoint(j).x);
+          }
+      }
+
+    wBary.Reciprocal();
+    D_T = 0.0;
+    for (int iL = 0; iL < Np_x; iL++)
+      {
+        for (int i = 0; i < Np_x; i++)
+          {
+            if (iL != i)
+              {
+                D_T(i, iL) = wBary(iL) / wBary(i) / (cache->ir->IntPoint(i).x - cache->ir->IntPoint(iL).x);
+                D_T(i, i) -= D_T(i, iL);
+              }
+          }
+      }
+
+    Dhat_T = D_T;
+    Dhat_T(0, 0) += 1.0 / cache->ir->IntPoint(0).weight;
+    Dhat_T(Np - 1, Np - 1) -= 1.0 / cache->ir->IntPoint(Np - 1).weight;
+    Dhat_T.Transpose();
+
+    Dhat2_T = D_T;
+    Dhat2_T *= 2.0;
+    Dhat2_T(0, 0) += 1.0 / cache->ir->IntPoint(0).weight;
+    Dhat2_T(Np - 1, Np - 1) -= 1.0 / cache->ir->IntPoint(Np - 1).weight;
+    Dhat2_T.Transpose();
+    D_T.Transpose();
+
+    // Just copy D_T, Dhat_T, and Dhat2_T
+    cache->D.SetSize(Np_x*Np_x);
+    cache->Dhat.SetSize(Np_x*Np_x);
+    cache->Dhat2.SetSize(Np_x*Np_x);
+    std::memcpy(cache->D.HostWrite(),     D_T.Data(),     sizeof(real_t)*Np_x*Np_x);
+    std::memcpy(cache->Dhat.HostWrite(),  Dhat_T.Data(),  sizeof(real_t)*Np_x*Np_x);
+    std::memcpy(cache->Dhat2.HostWrite(), Dhat2_T.Data(), sizeof(real_t)*Np_x*Np_x);
+
+    cache->elWaveSpeed.SetSize(nelem);
+    cache->elWaveSpeed = 0.0;
+    cache->elWaveSpeed.UseDevice();
+    cache->elWaveSpeed.Read();
+
+    cache->elJac.UseDevice();
+    cache->elMetric.UseDevice();
+    cache->D.UseDevice();
+    cache->Dhat.UseDevice();
+    cache->Dhat2.UseDevice();
+    cache->elJac.Read();
+    cache->elMetric.Read();
+    cache->D.Read();
+    cache->Dhat.Read();
+    cache->Dhat2.Read();
+
+    // Set up data for faces
+    const int nfp = cache->ir_face->GetNPoints();
+    cache->num_face_points = nfp;
+
+    const int nfaces_restr = cache->restr_f->Height() / (nfp * neq * 2);
+    cache->num_interior_faces = nfaces_restr;
+    MFEM_VERIFY(nfaces_restr > 0, "nfaces_restr is 0");
+
+    cache->face_normals.SetSize(nfaces_restr * nfp * dim);
+    cache->face_wt_minus.SetSize(nfaces_restr * nfp);
+    cache->face_wt_plus.SetSize(nfaces_restr * nfp);
+    AssembleInteriorFaceGeometryTerms(fes, cache);
+    
+    cache->face_normals.UseDevice();
+    cache->face_wt_minus.UseDevice();
+    cache->face_wt_plus.UseDevice();
+    cache->face_normals.Read();
+    cache->face_wt_minus.Read();
+    cache->face_wt_plus.Read();
+
+    cache->ifWaveSpeed.SetSize(cache->num_interior_faces);
+    cache->ifWaveSpeed = 0.0;
+    cache->ifWaveSpeed.UseDevice();
+    cache->ifWaveSpeed.Read();
+  }
+
+
+  template<typename CacheT>
+  void SetupVolumeMarkers(mfem::FiniteElementSpace *fes, CacheT *cache)
+  {
+    mfem::Mesh *mesh = fes->GetMesh();
+    
+    cache->num_attr = mesh->attributes.Size() ? mesh->attributes.Max() : 0;
+    cache->vol_attr_marker.SetSize(cache->num_attr);
+    cache->vol_attr_marker = 1; // process everything
+
+    cache->domain_attr_marker.SetSize(cache->num_attr);
+    cache->domain_attr_marker = 1; // process everything
+    
+    // ---- 2) Per-element attribute id array -----------------------------------
+    const int ne = mesh->GetNE();
+    cache->elem_attr.SetSize(ne);
+    for (int e = 0; e < ne; ++e)
+      {
+        const int attr = mesh->GetAttribute(e); // 1-based
+        cache->elem_attr[e] = attr;
+      }
+
+    // Optional host-side sanity check (cheap, catches bad markers early):
+    if (cache->num_attr > 0)
+      {
+        for (int e = 0; e < ne; ++e)
+          {
+            const int a = cache->elem_attr[e];
+            MFEM_VERIFY(a >= 1 && a <= cache->num_attr,
+                        "element attribute out of range: attr=" << a
+                        << " num_attr=" << cache->num_attr);
+          }
+      }
+
+    cache->elem_attr.UseDevice();
+    cache->vol_attr_marker.UseDevice();
+    cache->domain_attr_marker.UseDevice();
+    cache->elem_attr.Read();
+    cache->vol_attr_marker.Read();
+    cache->domain_attr_marker.Read();
+  }
+
+  
+  // Builds element-specific Jac/Metric and stuffs into cache.elJac, cache.elMetric
+  template<typename CacheT>
+  void AssembleElementVolumeGeometricTerms(mfem::ElementTransformation &Tr, CacheT *cache)
+  {
+    
+    real_t *Jinv_h = cache->elJac.HostWrite();
+    real_t *Met_h  = cache->elMetric.HostWrite();
+    int dim = cache->dim;
+    mfem::Vector metric1(dim);
+    const int e = Tr.ElementNo;
+    const int nq = cache->Np_x * cache->Np_y * cache->Np_z;
+    
+    for (int q = 0; q < nq; ++q)
+      {
+        const mfem::IntegrationPoint &ip = cache->ir_vol->IntPoint(q);
+        Tr.SetIntPoint(&ip);
+        const real_t J = Tr.Weight();
+        Jinv_h[e*nq + q] = J;
+        
+        const mfem::DenseMatrix &adj = Tr.AdjugateJacobian();              
+        for (int dir = 0; dir < dim; ++dir)
+          {
+            adj.GetRow(dir, metric1);  // metric1.Size() == dim
+            
+            for (int d = 0; d < dim; ++d)
+              {
+                const int idxM = (((e*nq + q)*dim + dir)*dim + d);
+                Met_h[idxM] = metric1(d);
+              }
+          }
+      }
+  }
+
+  //  void DGSEMNonlinearForm::AssembleFaceGeomCacheInterior()
+  template<typename CacheT>
+  void AssembleInteriorFaceGeometryTerms(mfem::FiniteElementSpace *fes, CacheT *cache)
+  {
+    auto *mesh = fes->GetMesh();
+    auto *pmesh = dynamic_cast<mfem::ParMesh*>(mesh);
+    auto *pfes = dynamic_cast<mfem::ParFiniteElementSpace*>(fes);
+    cache->fqs_int.reset(new mfem::FaceQuadratureSpace(*mesh, *cache->ir_face,
+                                                       mfem::FaceType::Interior));
+    MFEM_VERIFY(pfes, "need ParFiniteElementSpace");
+    
+    const int dim = mesh->Dimension();
+    const int neq = pfes->GetVDim();
+    const int nfp = cache->ir_face->GetNPoints();
+
+    auto &int_faces = pmesh->GetFaceIndices(mfem::FaceType::Interior);
+    const int ninterior_faces = int_faces.Size();
+
+    cache->inv_fp_map.SetSize(ninterior_faces * nfp);    
+    for (int face_slot = 0; face_slot < ninterior_faces; ++face_slot)
+      {
+        for (int fp_restr = 0; fp_restr < nfp; ++fp_restr)
+          {
+            int fp_perm = cache->fqs_int->GetPermutedIndex(face_slot, fp_restr);
+            cache->inv_fp_map[face_slot*nfp + fp_perm] = fp_restr;
+          }
+      }
+
+    real_t *nor_d  = cache->face_normals.HostWrite();
+    real_t *inv1_d = cache->face_wt_minus.HostWrite();
+    real_t *inv2_d = cache->face_wt_plus.HostWrite();
+    const real_t w0 = cache->ir->IntPoint(0).weight;
+    
+    auto store = [&](int fslot, int fp, const mfem::Vector &nor,
+                     real_t inv_wJ1, real_t inv_wJ2)
+    {
+      const int nbase = (fslot * nfp + fp) * dim;
+      for (int d = 0; d < dim; ++d) { nor_d[nbase + d] = nor(d); }
+      inv1_d[fslot * nfp + fp] = inv_wJ1;
+      inv2_d[fslot * nfp + fp] = inv_wJ2;
+    };
+    
+    mfem::Vector nor(dim);
+    const int num_elements_pmesh = pmesh->GetNE();
+    // The order of faces in GetFaceIndices(FaceType::Interior) *must*
+    // match the order of the faces in the interior face restriction
+    // operator face slots.
+    for (int fslot = 0; fslot < ninterior_faces; ++fslot)
+      {
+        const int face_id = int_faces[fslot];  
+        bool face_is_flipped = false;
+        for (int fp_restr = 0; fp_restr < nfp; ++fp_restr)
+          {
+            const int fp_geom = cache->MapFp(fslot, fp_restr);// <-- critical
+            if (fp_geom != fp_restr){
+              face_is_flipped = true;
+            }
+          }
+        auto *tr = mesh->GetInteriorFaceTransformations(face_id);
+        if (tr){ // Do interior face caching
+          //          MFEM_VERIFY(tr, "expected interior face");
+          for (int fp_restr = 0; fp_restr < nfp; ++fp_restr)
+            {
+              const int fp_geom = cache->MapFp(fslot, fp_restr);// <-- critical
+              const mfem::IntegrationPoint &ip = cache->ir_face->IntPoint(fp_geom);
+              tr->SetAllIntPoints(&ip);
+              
+              const real_t J1 = tr->GetElement1Transformation().Weight();
+              const real_t J2 = tr->GetElement2Transformation().Weight();
+              
+              if (dim == 1) { nor(0) = (tr->GetElement1IntPoint().x - 0.5)*2.0; }
+              else          { mfem::CalcOrtho(tr->Jacobian(), nor); }
+              
+              //const real_t fac = face_is_flipped ? -1.0 : 1.0;
+              const real_t fac = 1.0;
+              store(fslot, fp_restr, nor, fac/(w0*J1), fac/(w0*J2));
+            }
+          continue;
+        } // Internal face processing
+        {
+          auto *sh_tr = pmesh->GetSharedFaceTransformationsByLocalIndex(face_id, true);
+          MFEM_VERIFY(sh_tr, "expected shared face");
+          for (int fp_restr = 0; fp_restr < nfp; ++fp_restr)
+            {
+              const int fp_geom = cache->MapFp(fslot, fp_restr);// <-- critical
+              const mfem::IntegrationPoint &ip = cache->ir_face->IntPoint(fp_geom);
+              sh_tr->SetAllIntPoints(&ip);
+              
+              const real_t J1 = sh_tr->GetElement1Transformation().Weight();
+              const real_t J2 = sh_tr->GetElement2Transformation().Weight();
+              
+              if (dim == 1) { nor(0) = (sh_tr->GetElement1IntPoint().x - 0.5)*2.0; }
+              else          { mfem::CalcOrtho(sh_tr->Jacobian(), nor); }
+              
+              //const real_t fac = face_is_flipped ? -1.0 : 1.0;
+              const real_t fac1 = 1.0;
+              const real_t fac2 = 0.0;
+              store(fslot, fp_restr, nor, fac1/(w0*J1), fac2/(w0*J2));
+            }
+        } // Shared face processing
+      }
+  }
+
+  template<typename CacheT, typename DeviceCacheT>
+  void GetDeviceCache(CacheT &cache, DeviceCacheT &device_cache)
+  {
+    // Fixed data items
+    device_cache.ndof_scalar_el = cache.ndof_scalar_el;
+    device_cache.num_attr = cache.num_attr;
+    device_cache.attr_marker_d = cache.vol_attr_marker.Read();
+    device_cache.elem_attr_d = cache.elem_attr.Read();
+    device_cache.num_face_points = cache.num_face_points;
+    device_cache.p = cache.p;
+    device_cache.dim = cache.dim;
+    device_cache.Np = cache.Np;
+    device_cache.Np_x = cache.Np_x;
+    device_cache.Np_y = cache.Np_y;
+    device_cache.Np_z = cache.Np_z;
+    device_cache.num_elements = cache.num_elements;
+    device_cache.num_equations = cache.num_equations;
+    device_cache.elJac_d = cache.elJac.Read();
+    device_cache.elMetric_d = cache.elMetric.Read();
+    device_cache.D_d = cache.D.Read();
+    device_cache.Dhat_d = cache.Dhat.Read();
+    device_cache.Dhat2_d = cache.Dhat2.Read();
+    device_cache.nor_d = cache.face_normals.Read();
+    device_cache.fw_minus_d = cache.face_wt_minus.Read();
+    device_cache.fw_plus_d = cache.face_wt_plus.Read();
+
+    // Updated every step by the compute device
+    device_cache.elWaveSpeed_d = cache.elWaveSpeed.Write();
+    device_cache.ifWaveSpeed_d = cache.ifWaveSpeed.Write();
+
+    // POD gas model
+    device_cache.gas = cache.gas;
+    device_cache.iflux = cache.iflux;
+ 
+  }
+
+  template<typename CacheT>
+  void OutputCacheContents(const CacheT &cache)
+  {
+    std::cout << "Cache Contents:" << std::endl
+              << "p = " << cache.p << std::endl
+              << "dim = " << cache.dim << std::endl
+              << "num_elements = " << cache.num_elements << std::endl
+              << "Np,Np_x,Np_y,Np_z = " << cache.Np << "," << cache.Np_x
+              << "," << cache.Np_y << "," << cache.Np_z << std::endl
+              << "num_face_points = " << cache.num_face_points << std::endl
+              << "num_attr = " << cache.num_attr << std::endl
+              << "ndof_scalar_el = " << cache.ndof_scalar_el << std::endl
+              << "num_interior_faces = " << cache.num_interior_faces << std::endl;
+    MFEM_VERIFY(cache.ir, "IR is not set");
+    MFEM_VERIFY(cache.ir_face, "Face IR not set");
+    MFEM_VERIFY(cache.ir_vol, "Volume IR not set");
+    MFEM_VERIFY(cache.restr_v, "Volume Restriction not set");
+    MFEM_VERIFY(cache.restr_f, "Facial Restriction not set");
+    MFEM_VERIFY(cache.ndof_scalar_el == cache.Np_x*cache.Np_y*cache.Np_z,
+                "Element dof count not equal to num quadrature points.");
+    int ds_size = cache.elem_attr.Size();
+    MFEM_VERIFY(ds_size > 0, "Elem attr not set");
+
+    ds_size = cache.elWaveSpeed.Size();
+    MFEM_VERIFY(ds_size == cache.num_elements, "Element wavespeeds missized.");
+    ds_size = cache.bndWaveSpeed.Size();
+    ds_size = cache.elJac.Size();
+    MFEM_VERIFY(ds_size > 0, "Element Jacobians not set");
+    ds_size = cache.elMetric.Size();
+    MFEM_VERIFY(ds_size > 0, "Element Metrics not set");
+    ds_size = cache.D.Size();
+    MFEM_VERIFY(ds_size > 0, "Deriv operator not set");
+    ds_size = cache.Dhat2.Size();
+    MFEM_VERIFY(ds_size > 0, "Dhat2 operator not set");
+    ds_size = cache.face_normals.Size();
+    MFEM_VERIFY(ds_size == cache.num_face_points*cache.num_interior_faces*cache.dim,
+                "Inapropriately sized face normals");
+    ds_size = cache.face_wt_minus.Size();
+    ds_size = cache.face_wt_plus.Size();
+    MFEM_VERIFY(ds_size > 0, "Face weights not set.");
+  }
+
+}

--- a/src/RiemannSolvers/ChandrashekarFlux.cpp
+++ b/src/RiemannSolvers/ChandrashekarFlux.cpp
@@ -11,141 +11,21 @@ namespace Prandtl
     metric.SetSize(dim);
   }
   
-real_t ChandrashekarFlux::ComputeVolumeFlux(const Vector &state1, const Vector &state2,
-                                            const Vector &metric1, const Vector &metric2,
-                                            Vector &F_tilde)
-{
-    ComputeMean(metric1, metric2, metric);
-    PointStateView S1{state1.GetData()};
-    PointStateView S2{state2.GetData()};
-    
-    const real_t rho1 = gasModel.density(S1);
-    const real_t rho2 = gasModel.density(S2);
-    const real_t rho_ln = ComputeLogMean(rho1, rho2);
-    const real_t drho = rho2 - rho1;
-    real_t mom[3] = {0.0, 0.0, 0.0};
-    real_t h_hat = 0.0;
-    real_t vn = 0.0;
-    real_t v_21 = 0.0;
-    real_t v_22 = 0.0;
-    for(int idim = 0; idim < dim; idim++){
-      real_t v1 = gasModel.velocity(S1, idim);
-      real_t v2 = gasModel.velocity(S2, idim);
-      real_t v_bar = 0.5*(v1 + v2);
-      v_21 += v1*v1;
-      v_22 += v2*v2;
-      vn += v_bar * metric(idim);
-      mom[idim] = rho_ln * v_bar;
-      h_hat += -0.25*(v1*v1 + v2*v2) + v_bar * v_bar;
-    }
-    
-    const real_t p1 = gasModel.pressure(S1);
-    const real_t p2 = gasModel.pressure(S2);
+  real_t ChandrashekarFlux::ComputeVolumeFlux(const Vector &state1, const Vector &state2,
+                                              const Vector &metric1, const Vector &metric2,
+                                              Vector &F_tilde)
+  {
+    return ComputeVolumeFluxKernel(gasModel, state1.GetData(), state2.GetData(),
+                                   metric1.GetData(), metric2.GetData(),
+                                   F_tilde.GetData());
+  }
 
-    const real_t speed1 = std::sqrt(v_21);
-    const real_t speed2 = std::sqrt(v_22);
 
-    const real_t c1 = gasModel.sound_speed(S1);
-    const real_t c2 = gasModel.sound_speed(S2);
-
-    const real_t lambda_1 = speed1 + c1;
-    const real_t lambda_max = std::max(lambda_1, speed2 + c2);
-
-    // These next bits are specific to single component ideal gas 
-    const real_t beta1 = 0.5 * rho1 / p1;
-    const real_t beta2 = 0.5 * rho2 / p2;
-    const real_t beta_ln = ComputeLogMean(beta1, beta2);
-
-    const real_t p_hat = 0.5 * (rho1 + rho2) / (beta1 + beta2);
-
-    // Use the average gamma for now
-    // TODO: Craft KEPEC fluxes for LTE/NLTE
-    const real_t gm11 = gasModel.gamma(S1);
-    const real_t gm12 = gasModel.gamma(S2);
-    const real_t gm1_av_inv = 2.0/(gm11 + gm12 - 2.0);
-
-    h_hat += 0.5 / beta_ln * gm1_av_inv + p_hat / rho_ln;
-
-    F_tilde(0) = rho_ln * vn;
-    for (int d = 0; d < dim; d++)
-    {
-        F_tilde(1 + d) = vn * mom[d] + p_hat * metric(d);
-    }
-    F_tilde(1 + dim) = rho_ln * vn * h_hat;
-
-    return lambda_max;
-}
-
-real_t ChandrashekarFlux::ComputeFaceFlux(const Vector &state1, const Vector &state2,
-                                          const Vector &nor, Vector &flux) const
-{
-    PointStateView S1{state1.GetData()};
-    PointStateView S2{state2.GetData()};
-    
-    const real_t nor_mag = nor.Norml2();
-
-    const real_t rho1 = gasModel.density(S1);
-    const real_t rho2 = gasModel.density(S2);
-    const real_t rho_mean = 0.5 * (rho1 + rho2);
-    const real_t rho_ln = ComputeLogMean(rho1, rho2);
-    const real_t drho = rho2 - rho1;
-    real_t mom[3] = {0.0, 0.0, 0.0};
-    real_t mom1[3] = {0.0, 0.0, 0.0};
-    real_t mom2[3] = {0.0, 0.0, 0.0};
-    real_t hhat = 0.0;
-    real_t diss = 0.0;
-    real_t v21 = 0.0;
-    real_t v22 = 0.0;
-    real_t vn = 0.0;
-    for(int idim = 0;idim < dim;idim++){
-      mom1[idim] = gasModel.momentum(S1, idim);
-      mom2[idim] = gasModel.momentum(S2, idim);
-      const real_t v1 = mom1[idim]/rho1;
-      const real_t v2 = mom2[idim]/rho2;
-      const real_t vbar = 0.5 * (v1 + v2);
-      const real_t dv = v2 - v1;
-      v21 += v1*v1;
-      v22 += v2*v2;
-      vn += vbar * nor(idim);
-      mom[idim] = rho_ln * vbar;
-      hhat += -0.25 * (v1*v1 + v2*v2) + vbar * vbar;
-      diss += 0.5 * drho * v1*v2 + rho_mean * dv * vbar;
-    }
-
-    const real_t p1 = gasModel.pressure(S1);
-    const real_t p2 = gasModel.pressure(S2);
-
-    const real_t vmag1 = std::sqrt(v21);
-    const real_t vmag2 = std::sqrt(v22);
-
-    const real_t c1 = gasModel.sound_speed(S1);
-    const real_t c2 = gasModel.sound_speed(S2);
-
-    const real_t lambda_max = std::max(vmag1+c1, vmag2+c2);
-
-    const real_t beta1 = 0.5 * rho1 / p1;
-    const real_t beta2 = 0.5 * rho2 / p2;
-    const real_t beta_ln = ComputeLogMean(beta1, beta2);
-
-    const real_t p_hat = 0.5 * (rho1 + rho2) / (beta1 + beta2);
-
-    // Use the average gamma for now
-    // TODO: Craft KEPEC fluxes for LTE/NLTE
-    const real_t gm11 = gasModel.gamma(S1);
-    const real_t gm12 = gasModel.gamma(S2); 
-    const real_t gm1_av_inv = 2.0/(gm11 + gm12 - 2.0);
-
-    hhat += 0.5 / beta_ln * gm1_av_inv + p_hat / rho_ln;
-    diss += 0.5 * drho * gm1_av_inv / beta_ln + 0.5 * rho_mean * gm1_av_inv * (1.0 / beta2 - 1.0 / beta1);
-
-    flux(0) = rho_ln * vn - 0.5 * lambda_max * (rho2 - rho1) * nor_mag;
-    for (int d = 0; d < dim; d++)
-    {
-      flux(1 + d) = vn * mom[d] + p_hat * nor(d) - 0.5 * lambda_max * (mom2[d]-mom1[d]) * nor_mag;
-    }
-    flux(1 + dim) = rho_ln * vn * hhat - 0.5 * lambda_max * diss * nor_mag;
-
-    return lambda_max;
-}
+  real_t ChandrashekarFlux::ComputeFaceFlux(const Vector &state1, const Vector &state2,
+                                            const Vector &nor, Vector &flux) const
+  {
+    return ComputeFaceFluxKernel(gasModel, state1.GetData(), state2.GetData(),
+                                 nor.GetData(), flux.GetData());
+  }
 
 }

--- a/src/RiemannSolvers/ChandrashekarFlux.hpp
+++ b/src/RiemannSolvers/ChandrashekarFlux.hpp
@@ -6,16 +6,205 @@
 namespace Prandtl
 {
 
-class ChandrashekarFlux : public NumericalFlux
-{
-private:
-  mutable Vector metric;
-  const IdealGasModel gasModel;
-public:
-  ChandrashekarFlux(const NavierStokesFlux &fluxFunction, const IdealGasModel &gasModel_);
-  real_t ComputeFaceFlux(const Vector &state1, const Vector &state2, const Vector &nor, Vector &flux) const override;
-  real_t ComputeVolumeFlux(const Vector &state1, const Vector &state2, const Vector &metric1, const Vector &metric2, Vector &F_tilde) override;
+  class ChandrashekarFlux : public NumericalFlux
+  {
+  private:
+    mutable Vector metric;
+    const IdealGasModel gasModel;
+  public:
+    ChandrashekarFlux(const NavierStokesFlux &fluxFunction, const IdealGasModel &gasModel_);
+    real_t ComputeFaceFlux(const Vector &state1, const Vector &state2,
+                           const Vector &nor, Vector &flux) const override;
+    real_t ComputeVolumeFlux(const Vector &state1, const Vector &state2, const Vector &metric1,
+                             const Vector &metric2, Vector &F_tilde) override;
+    
+    // This is Riemann solver that computes the numerical flux for 2 point states
+    // Will be ctx.iflux.ComputeVolumeFlux
+    template<typename GasModelT>
+    MFEM_HOST_DEVICE
+    inline static real_t ComputeVolumeFluxKernel(const GasModelT &gasModel,
+                                                 const real_t* q1,
+                                                 const real_t* q2,
+                                                 const real_t* met1,
+                                                 const real_t* met2,
+                                                 real_t* F_tilde)
+    {
+      const int dim = gasModel.dim();
+      const int neq = gasModel.num_equations();
+      
+      // mean metric row
+      real_t met[3] = {0,0,0};
+      Kernels::ComputeMeanVec(met1, met2, met, dim);
+      Prandtl::PointStateView S1{q1};
+      Prandtl::PointStateView S2{q2};
+      
+      const real_t rho1 = gasModel.density(S1);
+      const real_t rho2 = gasModel.density(S2);
+      const real_t rho_ln = Kernels::ComputeLogMean(rho1, rho2, 1e-4);
+      
+      real_t mom_hat[3] = {0,0,0};
+      real_t h_hat = 0;
+      real_t vn = 0;
+      real_t v2_1 = 0;
+      real_t v2_2 = 0;
+      
+      for (int d=0; d<dim; ++d)
+        {
+          const real_t v1 = gasModel.velocity(S1, d);
+          const real_t v2 = gasModel.velocity(S2, d);
+          const real_t vbar = real_t(0.5)*(v1+v2);
+          
+          v2_1 += v1*v1;
+          v2_2 += v2*v2;
+          vn   += vbar * met[d];
+          
+          mom_hat[d] = rho_ln * vbar;
+          
+          h_hat += -real_t(0.25)*(v1*v1 + v2*v2) + vbar*vbar;
+        }
+      
+      
+      const real_t p1 = gasModel.pressure(S1);
+      const real_t p2 = gasModel.pressure(S2);
+      
+      const real_t speed1 = Kernels::rsqrt(v2_1);
+      const real_t speed2 = Kernels::rsqrt(v2_2);
+      
+      const real_t c1 = gasModel.sound_speed(S1);
+      const real_t c2 = gasModel.sound_speed(S2);
+      
+      const real_t lambda_max = Kernels::rmax(speed1 + c1, speed2 + c2);
+      
+      // Single-component ideal-gas-specific KEPEC bits
+      // TODO: Update/Craft KPEC fluxes for mixtures (and passive scalar components)
+      const real_t beta1 = real_t(0.5) * rho1 / p1;
+      const real_t beta2 = real_t(0.5) * rho2 / p2;
+      const real_t beta_ln = Kernels::ComputeLogMean(beta1, beta2, 1e-4);
+      
+      const real_t p_hat = real_t(0.5) * (rho1 + rho2) / (beta1 + beta2);
+      
+      const real_t gm11 = gasModel.gamma(S1);
+      const real_t gm12 = gasModel.gamma(S2);
+      const real_t gm1_av_inv = real_t(2.0) / (gm11 + gm12 - real_t(2.0));
+      
+      h_hat += real_t(0.5) / beta_ln * gm1_av_inv + p_hat / rho_ln;
+      
+      // F_tilde layout: [rho, rhoV, rhoE]
+      // NOTE: Caller *must* zero(or own) F_tilde (size: neq)
+      // NOTE: HRM!  Why ZERO?  It appears that F_tilde is overwritten below
+      const int mass_eq = gasModel.L.eq_mass;
+      const int mom0_eq = gasModel.L.eq_mom0;
+      const int ener_eq = gasModel.L.eq_energy;
+      F_tilde[mass_eq] = rho_ln * vn;
+      for (int d=0; d<dim; ++d)
+        {
+          F_tilde[mom0_eq + d] = vn * mom_hat[d] + p_hat * met[d];
+        }
+      F_tilde[ener_eq] = rho_ln * vn * h_hat;
+      
+      // TODO: Updte for scalars, sigh
+      // for (s=0; s<num_scalars; ++s) F_tilde[XXXX]= XXX
+      
+      return lambda_max;
+    }
 
-};
+    template<typename GasModelT>
+    MFEM_HOST_DEVICE inline static real_t ComputeFaceFluxKernel(const GasModelT &gasModel,const real_t *state1,
+                                                                const real_t *state2, const real_t *nor,
+                                                                real_t *flux)
+    {
+      const int dim = gasModel.dim();
+      const int neq = gasModel.num_equations();
+      
+      Prandtl::PointStateView S1{state1};
+      Prandtl::PointStateView S2{state2};
+    
+      const real_t rho1 = gasModel.density(S1);
+      const real_t rho2 = gasModel.density(S2);
+      const real_t rho_mean = 0.5 * (rho1 + rho2);
+      const real_t rho_ln = Kernels::ComputeLogMean(rho1, rho2, 1e-4);
+      const real_t drho = rho2 - rho1;
+      real_t mom[3] = {0.0, 0.0, 0.0};
+      real_t mom1[3] = {0.0, 0.0, 0.0};
+      real_t mom2[3] = {0.0, 0.0, 0.0};
+      real_t hhat = 0.0;
+      real_t diss = 0.0;
+      real_t v21 = 0.0;
+      real_t v22 = 0.0;
+      real_t vn = 0.0;
+      real_t nor_mag = 0.0;
 
+      for(int idim = 0;idim < dim;idim++){
+        nor_mag += nor[idim]*nor[idim];
+        mom1[idim] = gasModel.momentum(S1, idim);
+        mom2[idim] = gasModel.momentum(S2, idim);
+        const real_t v1 = mom1[idim]/rho1;
+        const real_t v2 = mom2[idim]/rho2;
+        const real_t vbar = 0.5 * (v1 + v2);
+        const real_t dv = v2 - v1;
+        v21 += v1*v1;
+        v22 += v2*v2;
+        vn += vbar * nor[idim];
+        mom[idim] = rho_ln * vbar;
+        hhat += -0.25 * (v1*v1 + v2*v2) + vbar * vbar;
+        diss += 0.5 * drho * v1*v2 + rho_mean * dv * vbar;
+      }
+      nor_mag = std::sqrt(nor_mag);
+      
+      const real_t p1 = gasModel.pressure(S1);
+      const real_t p2 = gasModel.pressure(S2);
+
+      const real_t vmag1 = std::sqrt(v21);
+      const real_t vmag2 = std::sqrt(v22);
+
+      const real_t c1 = gasModel.sound_speed(S1);
+      const real_t c2 = gasModel.sound_speed(S2);
+
+      const real_t lambda_max = Kernels::rmax(vmag1 + c1, vmag2 + c2);
+
+      const real_t beta1 = 0.5 * rho1 / p1;
+      const real_t beta2 = 0.5 * rho2 / p2;
+      const real_t beta_ln = Kernels::ComputeLogMean(beta1, beta2, 1e-4);
+      
+      const real_t p_hat = 0.5 * (rho1 + rho2) / (beta1 + beta2);
+
+      // Use the average gamma for now
+      // TODO: Craft KEPEC fluxes for LTE/NLTE
+      const real_t gm11 = gasModel.gamma(S1);
+      const real_t gm12 = gasModel.gamma(S2); 
+      const real_t gm1_av_inv = 2.0/(gm11 + gm12 - 2.0);
+      
+      hhat += 0.5 / beta_ln * gm1_av_inv + p_hat / rho_ln;
+      diss += 0.5 * drho * gm1_av_inv / beta_ln + 0.5 * rho_mean * gm1_av_inv * (1.0 / beta2 - 1.0 / beta1);
+      const int mass_eq = gasModel.L.eq_mass;
+      const int mom0_eq = gasModel.L.eq_mom0;
+      const int ener_eq = gasModel.L.eq_energy;
+      
+      flux[mass_eq] = rho_ln * vn - 0.5 * lambda_max * (rho2 - rho1) * nor_mag;
+      for (int d = 0; d < dim; d++)
+        {
+          flux[mom0_eq + d] = vn * mom[d] + p_hat * nor[d] - 0.5 * lambda_max * (mom2[d]-mom1[d]) * nor_mag;
+        }
+      flux[ener_eq] = rho_ln * vn * hhat - 0.5 * lambda_max * diss * nor_mag;
+      
+      return lambda_max;
+    }
+    struct InviscidFlux {
+ 
+      template<typename GasModelT>
+      MFEM_HOST_DEVICE inline real_t ComputeVolumeFlux(const GasModelT &gasModel,
+                                                       const real_t *q1, const real_t *q2,
+                                                       const real_t *met1, const real_t *met2,
+                                                       real_t *F_tilde) const{
+        return ComputeVolumeFluxKernel(gasModel, q1, q2, met1, met2, F_tilde); 
+      }
+
+      template<typename GasModelT>
+      MFEM_HOST_DEVICE inline real_t ComputeFacialFlux(const GasModelT &gasModel,const real_t *qminus,
+                                                       const real_t *qplus, const real_t *nor,
+                                                       real_t *flux) const {
+        return ComputeFaceFluxKernel(gasModel, qminus, qplus, nor, flux); 
+      }
+    };
+  };
 }


### PR DESCRIPTION
## Pull request overview

This PR introduces a DGSEM operator caching layer intended to precompute and reuse discretization/restriction/geometric data, and refactors the Chandrashekar Riemann solver to expose host/device-friendly kernel entry points.

**Changes:**
- Refactor `ChandrashekarFlux` to route volume/face flux computations through templated `MFEM_HOST_DEVICE` kernels.
- Add DGSEM cache POD structs (`DGSEMOperatorCache`, `DGSEMDeviceCache`) plus utilities to populate geometric terms, restrictions, face normals/weights, and device pointers.
- Wire cache creation/assembly into `DGSEMOperator` and expose cache setters on `DGSEMNonlinearForm` / `DGSEMIntegrator`.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/RiemannSolvers/ChandrashekarFlux.hpp | Adds templated host/device flux kernels and a small inviscid-flux wrapper object. |
| src/RiemannSolvers/ChandrashekarFlux.cpp | Replaces prior implementations with thin wrappers calling the new kernels. |
| src/Operators/dgsem_cache.hpp | Adds cache structs for host/device operator data. |
| src/Operators/dgsem_cache_utilities.hpp | Adds cache construction/population utilities for restrictions, metrics, and face geometry. |
| src/Operators/NonlinearForm/DGSEMNonlinearForm.hpp | Adds cache/device-cache members and new includes. |
| src/Operators/DGSEMOperator.hpp | Adds cache members and cache-assembly hooks to the operator. |
| src/Operators/DGSEMOperator.cpp | Creates/populates the cache in the operator constructor and passes it to form/integrator. |
| src/Integrators/DGSEMIntegrator/DGSEMIntegrator.hpp | Adds cache pointer setter and includes cache/flux headers. |
| CMakeLists.txt | Updates the “disable optimizations” status message to use `${PROJECT_NAME}`. |
</details>

##### (copilot-generated)